### PR TITLE
Compare against `PHP_VERSION_ID` instead

### DIFF
--- a/src/SerializableClosure.php
+++ b/src/SerializableClosure.php
@@ -25,7 +25,7 @@ class SerializableClosure
      */
     public function __construct(Closure $closure)
     {
-        if (\PHP_VERSION_ID >= 70400) {
+        if (\PHP_VERSION_ID < 70400) {
             $this->serializable = new BaseSerializableClosure($closure);
         } else {
             $this->serializable = Serializers\Signed::$signer
@@ -62,7 +62,7 @@ class SerializableClosure
      */
     public static function setSecretKey($secret)
     {
-        if (\PHP_VERSION_ID >= 70400) {
+        if (\PHP_VERSION_ID < 70400) {
             $secret
                 ? BaseSerializableClosure::setSecretKey($secret)
                 : BaseSerializableClosure::removeSecurityProvider();

--- a/src/SerializableClosure.php
+++ b/src/SerializableClosure.php
@@ -62,7 +62,7 @@ class SerializableClosure
      */
     public static function setSecretKey($secret)
     {
-        if ((float) phpversion() < '7.4') {
+        if (\PHP_VERSION_ID >= 70400) {
             $secret
                 ? BaseSerializableClosure::setSecretKey($secret)
                 : BaseSerializableClosure::removeSecurityProvider();

--- a/src/SerializableClosure.php
+++ b/src/SerializableClosure.php
@@ -25,7 +25,7 @@ class SerializableClosure
      */
     public function __construct(Closure $closure)
     {
-        if ((float) phpversion() < '7.4') {
+        if (\PHP_VERSION_ID >= 70400) {
             $this->serializable = new BaseSerializableClosure($closure);
         } else {
             $this->serializable = Serializers\Signed::$signer


### PR DESCRIPTION
Note the inclusion of the leading slash too. Opcache is actually able to evaluate the guard at compile-time!