### PR TITLE
Fix use of nullsafe operator failing test

### DIFF
--- a/src/Support/ReflectionClosure.php
+++ b/src/Support/ReflectionClosure.php
@@ -5,6 +5,7 @@ namespace Laravel\SerializableClosure\Support;
 defined('T_NAME_QUALIFIED') || define('T_NAME_QUALIFIED', -4);
 defined('T_NAME_FULLY_QUALIFIED') || define('T_NAME_FULLY_QUALIFIED', -5);
 defined('T_FN') || define('T_FN', -6);
+defined('T_NULLSAFE_OBJECT_OPERATOR') || define('T_NULLSAFE_OBJECT_OPERATOR', -7);
 
 use Closure;
 use ReflectionFunction;
@@ -389,6 +390,7 @@ class ReflectionClosure extends ReflectionFunction
                             $lastState = 'closure';
                             break;
                         case T_OBJECT_OPERATOR:
+                        case T_NULLSAFE_OBJECT_OPERATOR:
                         case T_DOUBLE_COLON:
                             $code .= $token[1];
                             $lastState = 'closure';


### PR DESCRIPTION
FIxed the failing test in #16 using xdebug on php 8.0.11 it turns out that we missed a token

