### PR TITLE
[1.x] Updates stream protocol name to avoid collision with `opis/closure`

### DIFF
--- a/src/Support/ClosureStream.php
+++ b/src/Support/ClosureStream.php
@@ -7,7 +7,7 @@ class ClosureStream
     /**
      * The stream protocol.
      */
-    const STREAM_PROTO = 'closure';
+    const STREAM_PROTO = 'laravel-serializable-closure';
 
     /**
      * Checks if this stream is registered.
@@ -171,7 +171,7 @@ class ClosureStream
      */
     public static function register()
     {
-        if (! static::$isRegistered && ! in_array(static::STREAM_PROTO, stream_get_wrappers())) {
+        if (! static::$isRegistered) {
             static::$isRegistered = stream_wrapper_register(static::STREAM_PROTO, __CLASS__);
         }
     }


### PR DESCRIPTION
This pull request makes this package use its own stream protocol ID.

Previously, people can reach this edge case where they can end up deserializing an `laravel/serializable-closure` **before**  deserializing an `opis/closure`. As an example, having 2 web servers (one using a new version of Laravel / other using a new version Laravel), and both of them publish queue jobs for a queue server (using a new version of Laravel). When this edge case happens, they could occasionally see this error: `stream_wrapper_register(): Protocol closure:// is already defined.`.

Fixes https://github.com/laravel/serializable-closure/issues/22.