### PR TITLE
Fixes the serialization of `Enum` objects

### DIFF
--- a/src/Serializers/Native.php
+++ b/src/Serializers/Native.php
@@ -10,6 +10,7 @@ use Laravel\SerializableClosure\Support\ClosureStream;
 use Laravel\SerializableClosure\Support\ReflectionClosure;
 use Laravel\SerializableClosure\Support\SelfReference;
 use ReflectionObject;
+use UnitEnum;
 
 class Native implements Serializable
 {
@@ -459,7 +460,7 @@ class Native implements Serializable
 
             $instance = $data;
 
-            if (function_exists('enum_exists') && enum_exists(get_class($data))) {
+            if ($data instanceof UnitEnum) {
                 $this->scope[$instance] = $data;
 
                 return;

--- a/src/Serializers/Native.php
+++ b/src/Serializers/Native.php
@@ -458,6 +458,13 @@ class Native implements Serializable
             }
 
             $instance = $data;
+
+            if (function_exists('enum_exists') && enum_exists(get_class($data))) {
+                $this->scope[$instance] = $data;
+
+                return;
+            }
+
             $reflection = new ReflectionObject($data);
 
             if (! $reflection->isUserDefined()) {

--- a/tests/ReflectionClosurePhp81Test.php
+++ b/tests/ReflectionClosurePhp81Test.php
@@ -3,14 +3,13 @@
 use Foo\Baz\Qux\Forest;
 use Some\ClassName as ClassAlias;
 
-enum GlobalEnum: string {
-    case Admin = 'Administrator';
-    case Guest = 'Guest';
-    case Moderator = 'Moderator';
+enum GlobalEnum {
+    case Admin;
+    case Guest;
+    case Moderator;
 }
 
 test('enums', function () {
-
     $f = function (GlobalEnum $role) {
         return $role;
     };
@@ -21,10 +20,10 @@ test('enums', function () {
 
     expect($f)->toBeCode($e);
 
-    enum ScopedEnum: string {
-        case Admin = 'Administrator';
-        case Guest = 'Guest';
-        case Moderator = 'Moderator';
+    enum ScopedEnum {
+        case Admin;
+        case Guest;
+        case Moderator;
     }
 
     $f = function (ScopedEnum $role) {
@@ -32,6 +31,42 @@ test('enums', function () {
     };
 
     $e = 'function (\ScopedEnum $role) {
+        return $role;
+    }';
+
+    expect($f)->toBeCode($e);
+});
+
+
+enum GlobalBackedEnum: string {
+    case Admin = 'Administrator';
+    case Guest = 'Guest';
+    case Moderator = 'Moderator';
+}
+
+test('backed enums', function () {
+
+    $f = function (GlobalBackedEnum $role) {
+        return $role;
+    };
+
+    $e = 'function (\GlobalBackedEnum $role) {
+        return $role;
+    }';
+
+    expect($f)->toBeCode($e);
+
+    enum ScopedBackedEnum: string {
+        case Admin = 'Administrator';
+        case Guest = 'Guest';
+        case Moderator = 'Moderator';
+    }
+
+    $f = function (ScopedBackedEnum $role) {
+        return $role;
+    };
+
+    $e = 'function (\ScopedBackedEnum $role) {
         return $role;
     }';
 

--- a/tests/SerializerPhp81Test.php
+++ b/tests/SerializerPhp81Test.php
@@ -1,9 +1,9 @@
 <?php
 
-enum SerializerGlobalEnum: string {
-    case Admin = 'Administrator';
-    case Guest = 'Guest';
-    case Moderator = 'Moderator';
+enum SerializerGlobalEnum {
+    case Admin;
+    case Guest;
+    case Moderator;
 }
 
 test('enums', function () {
@@ -17,11 +17,21 @@ test('enums', function () {
         SerializerGlobalEnum::Guest
     );
 
+    $role = SerializerGlobalEnum::Admin;
+
+    $f = function () use ($role) {
+        return $role;
+    };
+
+    $f = s($f);
+
+    expect($f())->toBe(SerializerGlobalEnum::Admin);
+
     if (! enum_exists(SerializerScopedEnum::class)) {
-        enum SerializerScopedEnum: string {
-            case Admin = 'Administrator';
-            case Guest = 'Guest';
-            case Moderator = 'Moderator';
+        enum SerializerScopedEnum {
+            case Admin;
+            case Guest;
+            case Moderator;
         }
     }
 
@@ -31,7 +41,72 @@ test('enums', function () {
 
     $f = s($f);
 
-    expect($f()->value)->toBe('Administrator');
+    expect($f()->name)->toBe('Admin');
+
+    $role = SerializerScopedEnum::Admin;
+
+    $f = function () use ($role) {
+        return $role;
+    };
+
+    $f = s($f);
+
+    expect($f())->toBe(SerializerScopedEnum::Admin);
+})->with('serializers');
+
+enum SerializerGlobalBackedEnum: string {
+    case Admin = 'Administrator';
+    case Guest = 'Guest';
+    case Moderator = 'Moderator';
+}
+
+test('backed enums', function () {
+    $f = function (SerializerGlobalBackedEnum $role) {
+        return $role;
+    };
+
+    $f = s($f);
+
+    expect($f(SerializerGlobalBackedEnum::Guest))->toBe(
+        SerializerGlobalBackedEnum::Guest
+    );
+
+    $role = SerializerGlobalBackedEnum::Admin;
+
+    $f = function () use ($role) {
+        return $role;
+    };
+
+    $f = s($f);
+
+    expect($f())->toBe(SerializerGlobalBackedEnum::Admin);
+
+    if (! enum_exists(SerializerScopedBackedEnum::class)) {
+        enum SerializerScopedBackedEnum: string {
+            case Admin = 'Administrator';
+            case Guest = 'Guest';
+            case Moderator = 'Moderator';
+        }
+    }
+
+    $f = function () {
+        return SerializerScopedBackedEnum::Admin;
+    };
+
+    $f = s($f);
+
+    expect($f())->name->toBe('Admin')
+        ->value->toBe('Administrator');
+
+    $role = SerializerScopedBackedEnum::Admin;
+
+    $f = function () use ($role) {
+        return $role;
+    };
+
+    $f = s($f);
+
+    expect($f())->toBe(SerializerScopedBackedEnum::Admin);
 })->with('serializers');
 
 test('array unpacking', function () {


### PR DESCRIPTION
This pull request fixes the serialization of Enum objects when those are imported via `use` or via `scope` on short closures.

Fixed #27.