### PR TITLE
[1.x] Fixes serialisation of closures with named arguments code

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -27,6 +27,7 @@
         </testsuite>
         <testsuite name="php80">
             <file phpVersion="8.0.0-dev" phpVersionOperator=">=">./tests/ReflectionClosurePhp80Test.php</file>
+            <file phpVersion="8.0.0-dev" phpVersionOperator=">=">./tests/SerializerPhp80Test.php</file>
         </testsuite>
         <testsuite name="php81">
             <file phpVersion="8.1.0-dev" phpVersionOperator=">=">./tests/ReflectionClosurePhp81Test.php</file>

--- a/src/Support/ReflectionClosure.php
+++ b/src/Support/ReflectionClosure.php
@@ -505,7 +505,7 @@ class ReflectionClosure extends ReflectionFunction
                                 $code .= $id_start.$token;
                             }
 
-                            break 2;
+                            break;
                         case T_NAME_QUALIFIED:
                         case T_NS_SEPARATOR:
                         case T_STRING:

--- a/src/Support/ReflectionClosure.php
+++ b/src/Support/ReflectionClosure.php
@@ -497,6 +497,15 @@ class ReflectionClosure extends ReflectionFunction
                     break;
                 case 'id_name':
                     switch ($token[0]) {
+                        // named arguments...
+                        case ':':
+                            if ($lastState === 'closure' && $context === 'root') {
+                                $state = 'ignore_next';
+                                $lastState = 'closure';
+                                $code .= $id_start.$token;
+                            }
+
+                            break 2;
                         case T_NAME_QUALIFIED:
                         case T_NS_SEPARATOR:
                         case T_STRING:

--- a/tests/ReflectionClosurePhp80Test.php
+++ b/tests/ReflectionClosurePhp80Test.php
@@ -88,13 +88,45 @@ test('named arguments', function () {
     expect($f1)->toBeCode($e1);
 })->with('serializers');
 
-test('named arguments within closures', function () {
+test('single named argument within closures', function () {
     $f1 = function () {
-        return (new NamedArguments)->publicMethod(namedArgument: 'string');
+        return (new ReflectionClosurePhp80NamedArguments)->publicMethod(namedArgument: 'string');
     };
 
     $e1 = "function () {
-        return (new \NamedArguments)->publicMethod(namedArgument: 'string');
+        return (new \ReflectionClosurePhp80NamedArguments)->publicMethod(namedArgument: 'string');
+    }";
+
+    expect($f1)->toBeCode($e1);
+})->with('serializers');
+
+test('multiple named arguments within closures', function () {
+    $f1 = function () {
+        return (new ReflectionClosurePhp80NamedArguments)->publicMethod(namedArgument: 'string', namedArgumentB: 1);
+    };
+
+    $e1 = "function () {
+        return (new \ReflectionClosurePhp80NamedArguments)->publicMethod(namedArgument: 'string', namedArgumentB: 1);
+    }";
+
+    expect($f1)->toBeCode($e1);
+})->with('serializers');
+
+test('multiple named arguments within nested closures', function () {
+    $f1 = function () {
+        $fn = fn ($namedArgument, $namedArgumentB) => (
+            new ReflectionClosurePhp80NamedArguments
+        )->publicMethod(namedArgument: $namedArgument, namedArgumentB: $namedArgumentB);
+
+        return $fn(namedArgument: 'string', namedArgumentB: 1);
+    };
+
+    $e1 = "function () {
+        \$fn = fn (\$namedArgument, \$namedArgumentB) => (
+            new \ReflectionClosurePhp80NamedArguments
+        )->publicMethod(namedArgument: \$namedArgument, namedArgumentB: \$namedArgumentB);
+
+        return \$fn(namedArgument: 'string', namedArgumentB: 1);
     }";
 
     expect($f1)->toBeCode($e1);
@@ -102,9 +134,9 @@ test('named arguments within closures', function () {
 
 class ReflectionClosurePhp80NamedArguments
 {
-    public function publicMethod(string $namedArgument)
+    public function publicMethod(string $namedArgument, $namedArgumentB = null)
     {
-        return $namedArgument;
+        return $namedArgument.(string) $namedArgumentB;
     }
 }
 

--- a/tests/ReflectionClosurePhp80Test.php
+++ b/tests/ReflectionClosurePhp80Test.php
@@ -93,7 +93,7 @@ test('named arguments within closures', function () {
         return (new NamedArguments)->publicMethod(namedArgument: 'string');
     };
 
-    $e1 = "<?php function (string \$firstName, string \$lastName) {
+    $e1 = "function () {
         return (new \NamedArguments)->publicMethod(namedArgument: 'string');
     }";
 

--- a/tests/ReflectionClosurePhp80Test.php
+++ b/tests/ReflectionClosurePhp80Test.php
@@ -81,23 +81,32 @@ test('named arguments', function () {
         return $firstName.' '.$lastName;
     };
 
-    expect('Marco Deleu')->toBe(s($f1)(
-        lastName: 'Deleu',
-        firstName: 'Marco'
-    ));
+    $e1 = "function (string \$firstName, string \$lastName) {
+        return \$firstName.' '.\$lastName;
+    }";
+
+    expect($f1)->toBeCode($e1);
 })->with('serializers');
 
-test('constructor property promotion', function () {
-    $class = new PropertyPromotion('public', 'protected', 'private');
+test('named arguments within closures', function () {
+    $f1 = function () {
+        return (new NamedArguments)->publicMethod(namedArgument: 'string');
+    };
 
-    $f1 = fn () => $class;
+    $e1 = "<?php function (string \$firstName, string \$lastName) {
+        return (new \NamedArguments)->publicMethod(namedArgument: 'string');
+    }";
 
-    $object = s($f1)();
-
-    expect($object->public)->toBe('public');
-    expect($object->getProtected())->toBe('protected');
-    expect($object->getPrivate())->toBe('private');
+    expect($f1)->toBeCode($e1);
 })->with('serializers');
+
+class ReflectionClosurePhp80NamedArguments
+{
+    public function publicMethod(string $namedArgument)
+    {
+        return $namedArgument;
+    }
+}
 
 class PropertyPromotion
 {

--- a/tests/SerializerPhp80Test.php
+++ b/tests/SerializerPhp80Test.php
@@ -11,18 +11,42 @@ test('named arguments', function () {
     ));
 })->with('serializers');
 
-test('named arguments within closures', function () {
+test('single named argument within closures', function () {
     $f1 = function () {
-        return (new NamedArguments)->publicMethod(namedArgument: 'string');
+        return (new SerializerPhp80NamedArguments)->publicMethod(
+            namedArgument: 'string'
+        );
     };
 
     expect('string')->toBe(s($f1)());
 })->with('serializers');
 
+test('multiple named arguments within closures', function () {
+    $f1 = function () {
+        return (new SerializerPhp80NamedArguments)->publicMethod(
+            namedArgument: 'string', namedArgumentB: 1
+        );
+    };
+
+    expect('string1')->toBe(s($f1)());
+})->with('serializers');
+
+test('multiple named arguments within nested closures', function () {
+    $f1 = function () {
+        $fn = fn ($namedArgument, $namedArgumentB) => (
+            new SerializerPhp80NamedArguments
+        )->publicMethod(namedArgument: $namedArgument, namedArgumentB: $namedArgumentB);
+
+        return $fn(namedArgument: 'string', namedArgumentB: 1);
+    };
+
+    expect('string1')->toBe(s($f1)());
+})->with('serializers');
+
 class SerializerPhp80NamedArguments
 {
-    public function publicMethod(string $namedArgument)
+    public function publicMethod(string $namedArgument, $namedArgumentB = null)
     {
-        return $namedArgument;
+        return $namedArgument.(string) $namedArgumentB;
     }
 }

--- a/tests/SerializerPhp80Test.php
+++ b/tests/SerializerPhp80Test.php
@@ -1,0 +1,28 @@
+<?php
+
+test('named arguments', function () {
+    $f1 = function (string $firstName, string $lastName) {
+        return $firstName.' '.$lastName;
+    };
+
+    expect('Marco Deleu')->toBe(s($f1)(
+        lastName: 'Deleu',
+        firstName: 'Marco'
+    ));
+})->with('serializers');
+
+test('named arguments within closures', function () {
+    $f1 = function () {
+        return (new NamedArguments)->publicMethod(namedArgument: 'string');
+    };
+
+    expect('string')->toBe(s($f1)());
+})->with('serializers');
+
+class SerializerPhp80NamedArguments
+{
+    public function publicMethod(string $namedArgument)
+    {
+        return $namedArgument;
+    }
+}

--- a/tests/SerializerPhp81Test.php
+++ b/tests/SerializerPhp81Test.php
@@ -216,6 +216,18 @@ test('final class constants', function () {
     expect($f())->toBe('foo');
 })->with('serializers');
 
+test('constructor property promotion', function () {
+    $class = new PropertyPromotion('public', 'protected', 'private');
+
+    $f1 = fn () => $class;
+
+    $object = s($f1)();
+
+    expect($object->public)->toBe('public');
+    expect($object->getProtected())->toBe('protected');
+    expect($object->getPrivate())->toBe('private');
+})->with('serializers');
+
 interface SerializerPhp81HasId {}
 interface SerializerPhp81HasName {}
 


### PR DESCRIPTION
This pull request closes https://github.com/laravel/serializable-closure/issues/30, by fixing the serialisation of named arguments. 