### PR TITLE
Fix PHP minimum req documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Laravel Serializable Closure provides an easy and secure way to **serialize clos
 
 ### Installation
 
-> **Requires [PHP 7.4+](https://php.net/releases/)**
+> **Requires [PHP 7.3+](https://php.net/releases/)**
 
 First, install Laravel Serializable Closure via the [Composer](https://getcomposer.org/) package manager:
 


### PR DESCRIPTION
Since composer.json permits PHP 7.3, the README should not state that PHP 7.4 is the minimum requirement.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
