### PR TITLE
[1.x] Adds support for first class callable syntax

### DIFF
--- a/tests/SerializerPhp81Test.php
+++ b/tests/SerializerPhp81Test.php
@@ -154,7 +154,7 @@ test('readonly properties', function () {
     });
 })->with('serializers');
 
-test('first-class callable', function () {
+test('first-class callable with closures', function () {
     $f = function ($value) {
         return $value;
     };
@@ -172,6 +172,58 @@ test('first-class callable', function () {
     $f = s($f);
 
     expect($f(1)(2))->toBe(4);
+})->with('serializers');
+
+test('first-class callable with methods', function () {
+    $f = (new SerializerPhp81Controller())->publicGetter(...);
+
+    $f = s($f);
+
+    expect($f())->toBeInstanceOf(SerializerPhp81Service::class);
+
+    $f = (new SerializerPhp81Controller())->publicGetterResolver(...);
+
+    $f = s($f);
+
+    expect($f()()())->toBeInstanceOf(SerializerPhp81Service::class);
+})->with('serializers');
+
+test('first-class callable with static methods', function () {
+    $f = SerializerPhp81Controller::publicStaticGetter(...);
+
+    $f = s($f);
+
+    expect($f())->toBeInstanceOf(SerializerPhp81Service::class);
+
+    $f = SerializerPhp81Controller::publicStaticGetterResolver(...);
+
+    $f = s($f);
+
+    expect($f()()())->toBeInstanceOf(SerializerPhp81Service::class);
+})->with('serializers');
+
+test('first-class callable final method', function () {
+    $f = (new SerializerPhp81Controller())->finalPublicGetterResolver(...);
+
+    $f = s($f);
+
+    expect($f()()())->toBeInstanceOf(SerializerPhp81Service::class);
+
+    $f = SerializerPhp81Controller::finalPublicStaticGetterResolver(...);
+
+    $f = s($f);
+
+    expect($f()()())->toBeInstanceOf(SerializerPhp81Service::class);
+})->with('serializers');
+
+test('first-class callable self return type', function () {
+    $f = (new SerializerPhp81Controller())->getSelf(...);
+
+    $f = s($f);
+
+    $controller = new SerializerPhp81Controller();
+
+    expect($f($controller))->toBeInstanceOf(SerializerPhp81Controller::class);
 })->with('serializers');
 
 test('intersection types', function () {
@@ -242,6 +294,61 @@ class SerializerPhp81Controller
         public readonly SerializerPhp81Service $service = new SerializerPhp81Service(),
     ) {
         // ..
+    }
+
+    public function publicGetter()
+    {
+        return $this->privateGetter();
+    }
+
+    private function privateGetter()
+    {
+        return $this->service;
+    }
+
+    public static function publicStaticGetter()
+    {
+        return static::privateStaticGetter();
+    }
+
+    public static function privateStaticGetter()
+    {
+        return (new SerializerPhp81Controller())->service;
+    }
+
+    public function publicGetterResolver()
+    {
+        return $this->privateGetterResolver(...);
+    }
+
+    private function privateGetterResolver()
+    {
+        return fn () => $this->service;
+    }
+
+    public static function publicStaticGetterResolver()
+    {
+        return static::privateStaticGetterResolver(...);
+    }
+
+    public static function privateStaticGetterResolver()
+    {
+        return fn () => (new SerializerPhp81Controller())->service;
+    }
+
+    final public function finalPublicGetterResolver()
+    {
+        return $this->privateGetterResolver(...);
+    }
+
+    final public static function finalPublicStaticGetterResolver()
+    {
+        return static::privateStaticGetterResolver(...);
+    }
+
+    public function getSelf(self $instance): self
+    {
+        return $instance;
     }
 }
 


### PR DESCRIPTION
This pull request adds support for first class callable syntax.

Because the first class callable syntax result does not "look" like a regular closure when serialised, this pull request attempts to transform the result of the code to a regular closure. Let me show you some examples:

```php
// Assuming...
class Person {
    public function getName1() {}
    final public function getName2() {}
    public static function getName3() {}
}

// Assuming the following syntax, used within the Person class...
$1 = $this->getName1(...);
$2 = $this->getName2(...);
$2 = $this->getName3(...);

// The variables `$1`, `$2` and `$3`, when serialised / deserialised:
$1 = function () {} // bound to Person instance
$2 = function () {} // bound to Person instance
$3 = static function () {} // statically bound to Person instance
```

Fixes https://github.com/laravel/serializable-closure/issues/32.