### PR TITLE
Issue with implicitly imported class type hint

### DIFF
--- a/tests/SerializerPhp80Test.php
+++ b/tests/SerializerPhp80Test.php
@@ -43,6 +43,13 @@ test('multiple named arguments within nested closures', function () {
     expect('string1')->toBe(s($f1)());
 })->with('serializers');
 
+test('sets correct type hint for class within same namespace', function() {
+    $closure = Closure::fromCallable([new Tests\Stub\TypeHinted\IssueFactory, 'reproduceIssue']);
+
+    expect($closure())->toBeInstanceOf(Tests\Stub\TypeHinted\Issue::class);
+    expect(s($closure)())->toBeInstanceOf(Tests\Stub\TypeHinted\Issue::class);
+})->with('serializers');
+
 class SerializerPhp80NamedArguments
 {
     public function publicMethod(string $namedArgument, $namedArgumentB = null)

--- a/tests/Stub/TypeHinted/Issue.php
+++ b/tests/Stub/TypeHinted/Issue.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Stub\TypeHinted;
+
+final class Issue
+{
+}

--- a/tests/Stub/TypeHinted/IssueFactory.php
+++ b/tests/Stub/TypeHinted/IssueFactory.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Stub\TypeHinted;
+
+final class IssueFactory
+{
+    public function reproduceIssue(): Issue
+    {
+        return new Issue();
+    }
+}


### PR DESCRIPTION
This pull request adds tests for closure created from object method, which defines type-hint of object residing in the same namespace, which is therefore imported implicitly.