### PR TITLE
[1.x] Fixes first class callables namespaces

### DIFF
--- a/src/Support/ReflectionClosure.php
+++ b/src/Support/ReflectionClosure.php
@@ -96,7 +96,7 @@ class ReflectionClosure extends ReflectionFunction
         $builtin_types = self::getBuiltinTypes();
         $class_keywords = ['self', 'static', 'parent'];
 
-        $ns = $this->getNamespaceName();
+        $ns = $this->getClosureNamespaceName();
         $nsf = $ns == '' ? '' : ($ns[0] == '\\' ? $ns : '\\'.$ns);
 
         $_file = var_export($fileName, true);
@@ -1131,6 +1131,23 @@ class ReflectionClosure extends ReflectionFunction
         static::$functions[$key] = $functions;
         static::$constants[$key] = $constants;
         static::$structures[$key] = $structures;
+    }
+
+    /**
+     * Returns the namespace associated to the closure.
+     *
+     * @return string
+     */
+    protected function getClosureNamespaceName()
+    {
+        $ns = $this->getNamespaceName();
+
+        // First class callables...
+        if ($this->getName() !== '{closure}' && empty($ns) && ! is_null($this->getClosureScopeClass())) {
+            $ns = $this->getClosureScopeClass()->getNamespaceName();
+        }
+
+        return $ns;
     }
 
     /**

--- a/tests/Fixtures/Model.php
+++ b/tests/Fixtures/Model.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Tests\Fixtures;
+
+class Model
+{
+    public function make(Model $model): Model
+    {
+        return new Model();
+    }
+
+    public static function staticMake(Model $model): Model
+    {
+        return new Model();
+    }
+}

--- a/tests/ReflectionClosure5Test.php
+++ b/tests/ReflectionClosure5Test.php
@@ -4,6 +4,7 @@ use Foo\Bar as Baz;
 use Foo\Baz\Qux;
 use Foo\Baz\Qux\Forest;
 use Laravel\SerializableClosure\Support\ReflectionClosure;
+use Tests\Fixtures\Model;
 
 test('is short closure', function () {
     $f1 = fn () => 1;
@@ -148,6 +149,28 @@ test('typed properties', function () {
 test('group namespaces', function () {
     $f = fn (): Forest => new Forest();
     $e = 'fn (): \Foo\Baz\Qux\Forest => new \Foo\Baz\Qux\Forest()';
+
+    expect($f)->toBeCode($e);
+});
+
+test('from callable namespaces', function () {
+    $f = Closure::fromCallable([new Model, 'make']);
+
+    $e = 'function (\Tests\Fixtures\Model $model): \Tests\Fixtures\Model
+    {
+        return new \Tests\Fixtures\Model();
+    }';
+
+    expect($f)->toBeCode($e);
+});
+
+test('from static callable namespaces', function () {
+    $f = Closure::fromCallable([new Model, 'staticMake']);
+
+    $e = 'static function (\Tests\Fixtures\Model $model): \Tests\Fixtures\Model
+    {
+        return new \Tests\Fixtures\Model();
+    }';
 
     expect($f)->toBeCode($e);
 });

--- a/tests/ReflectionClosure5Test.php
+++ b/tests/ReflectionClosure5Test.php
@@ -3,8 +3,8 @@
 use Foo\Bar as Baz;
 use Foo\Baz\Qux;
 use Foo\Baz\Qux\Forest;
-use Laravel\SerializableClosure\Support\ReflectionClosure;
 use Tests\Fixtures\Model;
+use Laravel\SerializableClosure\Support\ReflectionClosure;
 
 test('is short closure', function () {
     $f1 = fn () => 1;
@@ -165,7 +165,7 @@ test('from callable namespaces', function () {
 });
 
 test('from static callable namespaces', function () {
-    $f = Closure::fromCallable([new Model, 'staticMake']);
+    $f = Closure::fromCallable([Model::class, 'staticMake']);
 
     $e = 'static function (\Tests\Fixtures\Model $model): \Tests\Fixtures\Model
     {

--- a/tests/ReflectionClosurePhp81Test.php
+++ b/tests/ReflectionClosurePhp81Test.php
@@ -2,6 +2,8 @@
 
 use Foo\Baz\Qux\Forest;
 use Some\ClassName as ClassAlias;
+use Tests\Fixtures\Model;
+use function Tests\Fixtures\{makeModel};
 
 enum GlobalEnum {
     case Admin;
@@ -255,6 +257,45 @@ test('final class constants', function () {
 
     expect($f)->toBeCode($e);
 })->skip('Constants in anonymous classes is not supported.');
+
+test('from function first-class callable namespaces', function () {
+    $model = new Model();
+
+    $f = $model->make(...);
+
+    $e = 'function (\Tests\Fixtures\Model $model): \Tests\Fixtures\Model
+    {
+        return new \Tests\Fixtures\Model();
+    }';
+
+    expect($f)->toBeCode($e);
+});
+
+test('first-class callable namespaces', function () {
+    $model = new Model();
+
+    $f = $model->make(...);
+
+    $e = 'function (\Tests\Fixtures\Model $model): \Tests\Fixtures\Model
+    {
+        return new \Tests\Fixtures\Model();
+    }';
+
+    expect($f)->toBeCode($e);
+});
+
+test('static first-class callable namespaces', function () {
+    $model = new Model();
+
+    $f = $model->staticMake(...);
+
+    $e = 'static function (\Tests\Fixtures\Model $model): \Tests\Fixtures\Model
+    {
+        return new \Tests\Fixtures\Model();
+    }';
+
+    expect($f)->toBeCode($e);
+});
 
 class ReflectionClosurePhp81Service
 {

--- a/tests/ReflectionClosurePhp81Test.php
+++ b/tests/ReflectionClosurePhp81Test.php
@@ -258,19 +258,6 @@ test('final class constants', function () {
     expect($f)->toBeCode($e);
 })->skip('Constants in anonymous classes is not supported.');
 
-test('from function first-class callable namespaces', function () {
-    $model = new Model();
-
-    $f = $model->make(...);
-
-    $e = 'function (\Tests\Fixtures\Model $model): \Tests\Fixtures\Model
-    {
-        return new \Tests\Fixtures\Model();
-    }';
-
-    expect($f)->toBeCode($e);
-});
-
 test('first-class callable namespaces', function () {
     $model = new Model();
 

--- a/tests/SerializerPhp81Test.php
+++ b/tests/SerializerPhp81Test.php
@@ -1,5 +1,7 @@
 <?php
 
+use Tests\Fixtures\Model;
+
 enum SerializerGlobalEnum {
     case Admin;
     case Guest;
@@ -278,6 +280,26 @@ test('constructor property promotion', function () {
     expect($object->public)->toBe('public');
     expect($object->getProtected())->toBe('protected');
     expect($object->getPrivate())->toBe('private');
+})->with('serializers');
+
+test('first-class callable namespaces', function () {
+    $model = new Model();
+
+    $f = $model->make(...);
+
+    $f = s($f);
+
+    expect($f(new Model))->toBeInstanceOf(Model::class);
+})->with('serializers');
+
+test('static first-class callable namespaces', function () {
+    $model = new Model();
+
+    $f = $model->staticMake(...);
+
+    $f = s($f);
+
+    expect($f(new Model))->toBeInstanceOf(Model::class);
 })->with('serializers');
 
 interface SerializerPhp81HasId {}

--- a/tests/SerializerTest.php
+++ b/tests/SerializerTest.php
@@ -3,6 +3,7 @@
 use Laravel\SerializableClosure\SerializableClosure;
 use Laravel\SerializableClosure\Serializers\Signed;
 use Laravel\SerializableClosure\Support\ReflectionClosure;
+use Tests\Fixtures\Model;
 
 test('closure use return value', function () {
     $a = 100;
@@ -382,6 +383,22 @@ test('rebound closure', function () {
     $r = $u();
 
     expect($r)->toEqual('Hi');
+})->with('serializers');
+
+test('from callable namespaces', function () {
+    $f = Closure::fromCallable([new Model, 'make']);
+
+    $f = s($f);
+
+    expect($f(new Model))->toBeInstanceOf(Model::class);
+})->with('serializers');
+
+test('from static callable namespaces', function () {
+    $f = Closure::fromCallable([new Model, 'staticMake']);
+
+    $f = s($f);
+
+    expect($f(new Model))->toBeInstanceOf(Model::class);
 })->with('serializers');
 
 class A


### PR DESCRIPTION
This pull request fixes the serialisation of first class callable closures. As the full qualified namespaces were not being used on types.

Closes https://github.com/laravel/serializable-closure/pull/38.

In other words:

```php
// giving the code
namespace App\Models;
class User { function getUser(): User {} };

// and the serialisation of
$user->getUser(...);

// before 🛑
return function (): User {}

// after ✅
return function (): \App\Models\User {}
```
