### PR TITLE
Added failing test for PHP8 attributes

### DIFF
--- a/tests/ReflectionClosurePhp80Test.php
+++ b/tests/ReflectionClosurePhp80Test.php
@@ -132,6 +132,19 @@ test('multiple named arguments within nested closures', function () {
     expect($f1)->toBeCode($e1);
 })->with('serializers');
 
+test('attributes', function () {
+    $f = #[MyAttribute] function () {};
+    $serializedF = s($f);
+
+    expect(countAttributes($f))->toBe(countAttributes($serializedF));
+})->with('serializers');
+
+#[\Attribute] class MyAttribute { }
+
+function countAttributes($closure) {
+    return count((new \ReflectionFunction($closure))->getAttributes());
+}
+
 class ReflectionClosurePhp80NamedArguments
 {
     public function publicMethod(string $namedArgument, $namedArgumentB = null)


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->


## Description

It seems like PHP8 Attributes are not properly serialized. When serializing a closure that was annotated with attributes, those cannot be received using `ReflectionFunction::getAttributes()` on the deserialized one (as shown by the test).

At the moment, Laravel does not use any attributes to change route behavior, but I can see this being useful in the future (for an example, see "Motivation"). If this is not intended to be supported, I feel like this should be at least documented in the "Caveats"-section of the Readme.

## Motivation

I tried to build a package that does something similar to [this closed PR on the laravel framework](https://github.com/laravel/framework/pull/36734). Basically you configure a middleware, annotate your controller/closure with an `Transactional`-attribute, and they will automatically be wrapped in a transaction:

```php
// web.php
Route::get('transactional', #[Transactional] function () {
    $a = User::factory()->create();
    $b = User::factory()->create();

    return [$a, $b];
}
```

This code works fine during development, but as soon as I run `php artisan optimize` and the route files are cached, the `Transactional` attribute disappears, and the function is _not_ wrapped inside a transaction anymore. This is due to the behavior shown in the test.