### PR TITLE
Adds Function Attributes support

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ echo $closure(); // james;
 
 ### Caveats
 
-Creating **anonymous classes** within closures is not supported.
+1. Creating **anonymous classes** within closures is not supported.
+2. Using attributes within closures is not supported.
 
 ## Contributing
 

--- a/src/Support/ReflectionClosure.php
+++ b/src/Support/ReflectionClosure.php
@@ -679,10 +679,18 @@ class ReflectionClosure extends ReflectionFunction
 
         if (PHP_VERSION_ID >= 80100) {
             $attributesCode = array_map(function ($attribute) {
+                $arguments = $attribute->getArguments();
+
                 $name = $attribute->getName();
-                $arguments = implode(', ', array_map(function ($argument) {
-                    return sprintf("'%s'", str_replace("'", "\\'", $argument));
-                }, $attribute->getArguments()));
+                $arguments = implode(', ', array_map(function ($argument, $key) {
+                    $argument = sprintf("'%s'", str_replace("'", "\\'", $argument));
+
+                    if (is_string($key)) {
+                        $argument = sprintf('%s: %s', $key, $argument);
+                    }
+
+                    return $argument;
+                }, $arguments, array_keys($arguments)));
 
                 return "#[$name($arguments)]";
             }, $this->getAttributes());

--- a/src/Support/ReflectionClosure.php
+++ b/src/Support/ReflectionClosure.php
@@ -676,6 +676,22 @@ class ReflectionClosure extends ReflectionFunction
         $this->isShortClosure = $isShortClosure;
         $this->isBindingRequired = $isUsingThisObject;
         $this->isScopeRequired = $isUsingScope;
+
+        if (PHP_VERSION_ID >= 80100) {
+            $attributesCode = array_map(function ($attribute) {
+                $name = $attribute->getName();
+                $arguments = implode(', ', array_map(function ($argument) {
+                    return sprintf("'%s'", str_replace("'", "\\'", $argument));
+                }, $attribute->getArguments()));
+
+                return "#[$name($arguments)]";
+            }, $this->getAttributes());
+
+            if (! empty($attributesCode)) {
+                $code = implode("\n", array_merge($attributesCode, [$code]));
+            }
+        }
+
         $this->code = $code;
 
         return $this->code;

--- a/tests/Fixtures/ModelAttribute.php
+++ b/tests/Fixtures/ModelAttribute.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Tests\Fixtures;
+
+#[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_FUNCTION)]
+class ModelAttribute
+{
+    // ..
+}

--- a/tests/ReflectionClosurePhp81Test.php
+++ b/tests/ReflectionClosurePhp81Test.php
@@ -318,6 +318,23 @@ EOF;
     expect($f)->toBeCode($e);
 });
 
+test('function attributes with named arguments', function () {
+    $model = new Model();
+
+    $f = #[MyAttribute(string: 'My " \' Argument 1', model:Model::class)] function () {
+        return false;
+    };
+
+    $e = <<<EOF
+#[MyAttribute(string: 'My " \' Argument 1', model: 'Tests\Fixtures\Model')]
+function () {
+        return false;
+    }
+EOF;
+
+    expect($f)->toBeCode($e);
+});
+
 test('function attributes with first-class callable with methods', function () {
     $model = new Model();
 

--- a/tests/ReflectionClosurePhp81Test.php
+++ b/tests/ReflectionClosurePhp81Test.php
@@ -284,6 +284,57 @@ test('static first-class callable namespaces', function () {
     expect($f)->toBeCode($e);
 });
 
+test('function attributes without arguments', function () {
+    $model = new Model();
+
+    $f = #[MyAttribute] function () {
+        return true;
+    };
+
+    $e = <<<EOF
+#[MyAttribute()]
+function () {
+        return true;
+    }
+EOF;
+
+    expect($f)->toBeCode($e);
+});
+
+test('function attributes with arguments', function () {
+    $model = new Model();
+
+    $f = #[MyAttribute('My " \' Argument 1', Model::class)] function () {
+        return true;
+    };
+
+    $e = <<<EOF
+#[MyAttribute('My " \' Argument 1', 'Tests\Fixtures\Model')]
+function () {
+        return true;
+    }
+EOF;
+
+    expect($f)->toBeCode($e);
+});
+
+test('function attributes with first-class callable with methods', function () {
+    $model = new Model();
+
+    $f = (new SerializerPhp81Controller())->publicGetter(...);
+
+    $e = <<<EOF
+#[Tests\Fixtures\ModelAttribute()]
+#[MyAttribute('My " \' Argument 1', 'Tests\Fixtures\Model')]
+function ()
+    {
+        return \$this->privateGetter();
+    }
+EOF;
+
+    expect($f)->toBeCode($e);
+});
+
 class ReflectionClosurePhp81Service
 {
 }

--- a/tests/SerializerPhp81Test.php
+++ b/tests/SerializerPhp81Test.php
@@ -348,6 +348,8 @@ test('function attributes with arguments', function () {
 test('function attributes with first-class callable with methods', function () {
     $f = (new SerializerPhp81Controller())->publicGetter(...);
 
+    $f = s($f);
+
     $reflector = new ReflectionFunction($f);
 
     expect($reflector->getAttributes())->sequence(

--- a/tests/SerializerPhp81Test.php
+++ b/tests/SerializerPhp81Test.php
@@ -345,6 +345,34 @@ test('function attributes with arguments', function () {
     expect($f())->toBeFalse();
 })->with('serializers');
 
+test('function attributes with named arguments', function () {
+    $model = new Model();
+
+    $f = #[MyAttribute(string: 'My " \' Argument 1', model:Model::class)] function () {
+        return false;
+    };
+
+    $f = s($f);
+
+    $reflector = new ReflectionFunction($f);
+
+    expect($reflector->getAttributes())->sequence(function ($attribute) {
+
+        $attribute
+            ->getName()->toBe(MyAttribute::class)
+            ->getArguments()->toBe([
+                'string' => 'My " \' Argument 1',
+                'model' => Model::class,
+            ]);
+
+        expect($attribute->value->newInstance())
+            ->string->toBe('My " \' Argument 1')
+            ->model->toBe(Model::class);
+    });
+
+    expect($f())->toBeFalse();
+})->with('serializers');
+
 test('function attributes with first-class callable with methods', function () {
     $f = (new SerializerPhp81Controller())->publicGetter(...);
 
@@ -443,6 +471,9 @@ class SerializerPhp81Controller
 #[Attribute(Attribute::TARGET_METHOD|Attribute::TARGET_FUNCTION)]
 class MyAttribute
 {
-    // ..
+    public function __construct(public $string, public $model)
+    {
+        // ..
+    }
 }
 


### PR DESCRIPTION
This pull request adds function attributes support to serialisable closures:

```php
#[Attribute(Attribute::TARGET_FUNCTION)]
class MyAttribute
{
    // ..
}

$closure = #[MyAttribute('My attribute argument')] function () {
    return true;
};

$closure = unserialize(serialize($closure))->getClosure();

// Before this pull request:
dd(new ReflectionFunction($closure))->getAttributes());
// []

// After this pull request:
dd(new ReflectionFunction($closure))->getAttributes());
// [['name' => 'MyAttribute', 'arguments' => ['My attribute argument']]]
```