### PR TITLE
Adds support for closure inside context with enum property

### DIFF
--- a/src/Serializers/Native.php
+++ b/src/Serializers/Native.php
@@ -242,7 +242,7 @@ class Native implements Serializable
             }
 
             unset($value);
-        } elseif (is_object($data) && ! $data instanceof static) {
+        } elseif (is_object($data) && ! $data instanceof static && ! $data instanceof UnitEnum) {
             if (isset($storage[$data])) {
                 $data = $storage[$data];
 

--- a/tests/SerializerPhp81Test.php
+++ b/tests/SerializerPhp81Test.php
@@ -3,12 +3,6 @@
 use Tests\Fixtures\Model;
 use Tests\Fixtures\ModelAttribute;
 
-enum SerializerGlobalEnum {
-    case Admin;
-    case Guest;
-    case Moderator;
-}
-
 test('enums', function () {
     $f = function (SerializerGlobalEnum $role) {
         return $role;
@@ -57,11 +51,16 @@ test('enums', function () {
     expect($f())->toBe(SerializerScopedEnum::Admin);
 })->with('serializers');
 
-enum SerializerGlobalBackedEnum: string {
-    case Admin = 'Administrator';
-    case Guest = 'Guest';
-    case Moderator = 'Moderator';
-}
+test('enums properties', function () {
+    $object = new ClassWithEnumProperty();
+    $f = $object->getClosure();
+
+    $f = s($f);
+
+    expect($f())
+        ->name->toBe('Admin')
+        ->value->toBeNull();
+})->with('serializers');
 
 test('backed enums', function () {
     $f = function (SerializerGlobalBackedEnum $role) {
@@ -110,6 +109,17 @@ test('backed enums', function () {
     $f = s($f);
 
     expect($f())->toBe(SerializerScopedBackedEnum::Admin);
+})->with('serializers');
+
+test('backed enums properties', function () {
+    $object = new ClassWithBackedEnumProperty();
+    $f = $object->getClosure();
+
+    $f = s($f);
+
+    expect($f())
+        ->name->toBe('Admin')
+        ->value->toBe('Administrator');
 })->with('serializers');
 
 test('array unpacking', function () {
@@ -394,15 +404,6 @@ test('function attributes with first-class callable with methods', function () {
     expect($f())->toBeInstanceOf(SerializerPhp81Service::class);
 })->with('serializers');
 
-test('closure defined inside class with enum property', function () {
-    $object = new ClassWithEnumField();
-    $f = $object->getClosure();
-
-    $f = s($f);
-
-    expect($f()->name)->toBe('Admin');
-})->with('serializers');
-
 interface SerializerPhp81HasId {}
 interface SerializerPhp81HasName {}
 
@@ -477,6 +478,18 @@ class SerializerPhp81Controller
     }
 }
 
+enum SerializerGlobalEnum {
+    case Admin;
+    case Guest;
+    case Moderator;
+}
+
+enum SerializerGlobalBackedEnum: string {
+    case Admin = 'Administrator';
+    case Guest = 'Guest';
+    case Moderator = 'Moderator';
+}
+
 #[Attribute(Attribute::TARGET_METHOD|Attribute::TARGET_FUNCTION)]
 class MyAttribute
 {
@@ -486,9 +499,21 @@ class MyAttribute
     }
 }
 
-class ClassWithEnumField
+class ClassWithEnumProperty
 {
     public SerializerGlobalEnum $enum = SerializerGlobalEnum::Admin;
+
+    public function getClosure()
+    {
+        return function () {
+            return $this->enum;
+        };
+    }
+}
+
+class ClassWithBackedEnumProperty
+{
+    public SerializerGlobalBackedEnum $enum = SerializerGlobalBackedEnum::Admin;
 
     public function getClosure()
     {

--- a/tests/SerializerPhp81Test.php
+++ b/tests/SerializerPhp81Test.php
@@ -394,6 +394,15 @@ test('function attributes with first-class callable with methods', function () {
     expect($f())->toBeInstanceOf(SerializerPhp81Service::class);
 })->with('serializers');
 
+test('closure defined inside class with enum property', function () {
+    $object = new ClassWithEnumField();
+    $f = $object->getClosure();
+
+    $f = s($f);
+
+    expect($f()->name)->toBe('Admin');
+})->with('serializers');
+
 interface SerializerPhp81HasId {}
 interface SerializerPhp81HasName {}
 
@@ -477,3 +486,14 @@ class MyAttribute
     }
 }
 
+class ClassWithEnumField
+{
+    public SerializerGlobalEnum $enum = SerializerGlobalEnum::Admin;
+
+    public function getClosure()
+    {
+        return function () {
+            return $this->enum;
+        };
+    }
+}


### PR DESCRIPTION
Fixes #43 

## Description

This PR fixes a bug when trying to serialize a closure that was defined inside a class where any class in its context has a property containing an enum. Since that's quite a mouthful, here's an example.

Given these enum and class declarations:

```php
enum MyEnum
{
    case Foo;
    case Bar;
}

class MyClass
{
    public MyEnum $enum = MyEnum::Foo;
    public Closure $closure;

    public function __construct()
    {
        $this->closure = function () {
            return $this->enum;
        };
    }
}
```

A couple important things to point out:

- The class `MyClass` has a property with an enum as its value. It's not actually important that this field exists on `MyClass` specifically. As long as some class _somewhere_ in the closure's context has a property with an enum as its value, the bug will still occur. So if `MyClass` had a property of type `MyOtherClass` and `MyOtherClass` had a property of type `MyEnum`, the same thing would happen.
- The closure it's referencing `$this`. This is important (maybe pun intended) because its what's triggering the call to `Serializers\Native::wrapClosures`.
- The `$enum` field actually has a value. If this was a nullable field and it happened to be `null` the error would not occur.

When this closure gets serialized, the serializer recursively walks through every property of `MyClass` (and all of its parent classes, if applicable) and and calls `wrapClosures` on each of them. Once it hits the property containing the enum, it crashes with a `Cannot instantiate enum MyEnum` error. This is because it's trying to call `ReflectionClass::newInstanceWithoutConstructor` on the enum which doesn't work.

## The fix

Since enums serialize just fine on their own, I fixed this by adding an additional base case to the respective `elseif` branch of the `wrapClosures` method to exclude instances of `UnitEnum`. The `is_object` call on its own is not specific enough since that returns `true` for `UnitEnum` as well.

I have added the simplest test case I could come up with to reproduce the error. I have also tested this patch on one of my current projects where I encountered this bug and everything seems to work.