### PR TITLE
fix: serializing date and carbon objects

### DIFF
--- a/src/Serializers/Native.php
+++ b/src/Serializers/Native.php
@@ -249,6 +249,12 @@ class Native implements Serializable
                 return;
             }
 
+            if (PHP_VERSION >= 7.1) {
+                if ($data instanceof \DateTime) {
+                    return;
+                }
+            }
+
             $instance = $data;
             $reflection = new ReflectionObject($instance);
 

--- a/src/Serializers/Native.php
+++ b/src/Serializers/Native.php
@@ -249,10 +249,8 @@ class Native implements Serializable
                 return;
             }
 
-            if (PHP_VERSION >= 7.1) {
-                if ($data instanceof \DateTime) {
-                    return;
-                }
+            if ($data instanceof \DateTime) {
+                return;
             }
 
             $instance = $data;


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

When trying to serialize properties that have date objects or carbon objects like when queuing a closure, I'm facing bugs/warnings similar to this: 
- `PHP Warning:  serialize(): "date" returned as member variable from __sleep()`
- `The DateTime object has not been correctly initialized by its constructor`

I found that the issue is with serializing the date objects and php version. Also found similar PRs.
https://github.com/opis/closure/issues/75
https://github.com/opis/closure/pull/113


