### PR TITLE
fix: serializing date and carbon objects

### DIFF
--- a/src/Serializers/Native.php
+++ b/src/Serializers/Native.php
@@ -249,6 +249,12 @@ class Native implements Serializable
                 return;
             }
 
+            if (PHP_VERSION >= 7.1) {
+                if ($data instanceof \DateTime) {
+                    return;
+                }
+            }
+
             $instance = $data;
             $reflection = new ReflectionObject($instance);
 

--- a/src/Serializers/Native.php
+++ b/src/Serializers/Native.php
@@ -249,10 +249,8 @@ class Native implements Serializable
                 return;
             }
 
-            if (PHP_VERSION >= 7.1) {
-                if ($data instanceof \DateTime) {
-                    return;
-                }
+            if ($data instanceof \DateTime) {
+                return;
             }
 
             $instance = $data;

--- a/tests/ReflectionClosure1Test.php
+++ b/tests/ReflectionClosure1Test.php
@@ -115,7 +115,7 @@ test('closure resolve arguments', function () {
     expect($f6)->toBeCode($e6);
 });
 
-test('cloure resolve in body', function () {
+test('closure resolve in body', function () {
     $f1 = function () {
         return new Bar();
     };

--- a/tests/SerializerTest.php
+++ b/tests/SerializerTest.php
@@ -401,6 +401,26 @@ test('from static callable namespaces', function () {
     expect($f(new Model))->toBeInstanceOf(Model::class);
 })->with('serializers');
 
+test('serializes datetime objects', function (){
+    $closure = function () {
+        return new DateTime('now');
+    };
+    $u = s($closure);
+    $r = $u();
+
+    expect($r)->toBeInstanceOf(DateTime::class);
+})->with('serializers');
+
+test('serializes formatted datetime objects', function (){
+    $closure = function () {
+        return date('Y-m-d');
+    };
+    $u = s($closure);
+    $r = $u();
+
+    expect($r)->toEqual(date('Y-m-d'));
+})->with('serializers');
+
 class A
 {
     protected static function aStaticProtected()

--- a/tests/SerializerTest.php
+++ b/tests/SerializerTest.php
@@ -401,7 +401,7 @@ test('from static callable namespaces', function () {
     expect($f(new Model))->toBeInstanceOf(Model::class);
 })->with('serializers');
 
-test('serializes datetime objects', function (){
+test('serializes datetime objects', function () {
     $closure = function () {
         return new DateTime('now');
     };
@@ -411,7 +411,7 @@ test('serializes datetime objects', function (){
     expect($r)->toBeInstanceOf(DateTime::class);
 })->with('serializers');
 
-test('serializes formatted datetime objects', function (){
+test('serializes formatted datetime objects', function () {
     $closure = function () {
         return date('Y-m-d');
     };


### PR DESCRIPTION
Reopen: https://github.com/laravel/serializable-closure/pull/52
