### PR TITLE
Fix serialization of carbon objects

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "php": "^7.3|^8.0"
     },
     "require-dev": {
+        "nesbot/carbon": "^2.61",
         "pestphp/pest": "^1.21.3",
         "phpstan/phpstan": "^1.8.2",
         "symfony/var-dumper": "^5.4.11"

--- a/src/Serializers/Native.php
+++ b/src/Serializers/Native.php
@@ -462,7 +462,7 @@ class Native implements Serializable
 
             if ($data instanceof \DateTime) {
                 $this->scope[$instance] = $data;
-                
+
                 return;
             }
 

--- a/src/Serializers/Native.php
+++ b/src/Serializers/Native.php
@@ -460,6 +460,12 @@ class Native implements Serializable
 
             $instance = $data;
 
+            if ($data instanceof \DateTime) {
+                $this->scope[$instance] = $data;
+                
+                return;
+            }
+
             if ($data instanceof UnitEnum) {
                 $this->scope[$instance] = $data;
 

--- a/src/Serializers/Native.php
+++ b/src/Serializers/Native.php
@@ -3,13 +3,13 @@
 namespace Laravel\SerializableClosure\Serializers;
 
 use Closure;
+use DateTimeInterface;
 use Laravel\SerializableClosure\Contracts\Serializable;
 use Laravel\SerializableClosure\SerializableClosure;
 use Laravel\SerializableClosure\Support\ClosureScope;
 use Laravel\SerializableClosure\Support\ClosureStream;
 use Laravel\SerializableClosure\Support\ReflectionClosure;
 use Laravel\SerializableClosure\Support\SelfReference;
-use DateTimeInterface;
 use ReflectionObject;
 use UnitEnum;
 

--- a/src/Serializers/Native.php
+++ b/src/Serializers/Native.php
@@ -9,6 +9,7 @@ use Laravel\SerializableClosure\Support\ClosureScope;
 use Laravel\SerializableClosure\Support\ClosureStream;
 use Laravel\SerializableClosure\Support\ReflectionClosure;
 use Laravel\SerializableClosure\Support\SelfReference;
+use DateTimeInterface;
 use ReflectionObject;
 use UnitEnum;
 
@@ -460,7 +461,7 @@ class Native implements Serializable
 
             $instance = $data;
 
-            if ($data instanceof \DateTime) {
+            if ($data instanceof DateTimeInterface) {
                 $this->scope[$instance] = $data;
 
                 return;

--- a/tests/SerializerTest.php
+++ b/tests/SerializerTest.php
@@ -401,6 +401,19 @@ test('from static callable namespaces', function () {
     expect($f(new Model))->toBeInstanceOf(Model::class);
 })->with('serializers');
 
+test('serializes carbon objects', function () {
+    $carbon = new \Carbon\Carbon('now');
+
+    $closure = function () use ($carbon){
+        return $carbon;
+    };
+
+    $u = s($closure);
+    $r = $u();
+
+    expect($r)->toEqual($carbon);
+})->with('serializers');
+
 class A
 {
     protected static function aStaticProtected()

--- a/tests/SerializerTest.php
+++ b/tests/SerializerTest.php
@@ -404,7 +404,7 @@ test('from static callable namespaces', function () {
 test('serializes carbon objects', function () {
     $carbon = new \Carbon\Carbon('now');
 
-    $closure = function () use ($carbon){
+    $closure = function () use ($carbon) {
         return $carbon;
     };
 

--- a/tests/SerializerTest.php
+++ b/tests/SerializerTest.php
@@ -414,6 +414,19 @@ test('serializes carbon objects', function () {
     expect($r)->toEqual($carbon);
 })->with('serializers');
 
+test('serializes carbon immutable objects', function () {
+    $carbon = new \Carbon\CarbonImmutable('now');
+
+    $closure = function () use ($carbon) {
+        return $carbon;
+    };
+
+    $u = s($closure);
+    $r = $u();
+
+    expect($r)->toEqual($carbon);
+})->with('serializers');
+
 class A
 {
     protected static function aStaticProtected()


### PR DESCRIPTION
This is related to https://github.com/laravel/serializable-closure/pull/53, but that fix did not work for the issue I was having with Carbon serialization.

Like that PR, the specific error I am getting is "The DateTime object has not been correctly initialized by its constructor".

This test does fail when the fix is commented out.

I decided to check for an instance of DateTime instead of Carbon specifically since it seems like others are having an issue with DateTime objects. However, I could not replicate the issue with a plain DateTime object, that's why I included the dev dependency of Carbon.

This issue informed the fix: https://github.com/laravel/framework/issues/43695