### PR TITLE
[1.x] Fixes serialization of date carbon objects

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "php": "^7.3|^8.0"
     },
     "require-dev": {
+        "nesbot/carbon": "^2.61",
         "pestphp/pest": "^1.21.3",
         "phpstan/phpstan": "^1.8.2",
         "symfony/var-dumper": "^5.4.11"

--- a/src/Serializers/Native.php
+++ b/src/Serializers/Native.php
@@ -3,6 +3,7 @@
 namespace Laravel\SerializableClosure\Serializers;
 
 use Closure;
+use DateTimeInterface;
 use Laravel\SerializableClosure\Contracts\Serializable;
 use Laravel\SerializableClosure\SerializableClosure;
 use Laravel\SerializableClosure\Support\ClosureScope;
@@ -459,6 +460,12 @@ class Native implements Serializable
             }
 
             $instance = $data;
+
+            if ($data instanceof DateTimeInterface) {
+                $this->scope[$instance] = $data;
+
+                return;
+            }
 
             if ($data instanceof UnitEnum) {
                 $this->scope[$instance] = $data;

--- a/tests/SerializerTest.php
+++ b/tests/SerializerTest.php
@@ -401,6 +401,32 @@ test('from static callable namespaces', function () {
     expect($f(new Model))->toBeInstanceOf(Model::class);
 })->with('serializers');
 
+test('serializes carbon objects', function () {
+    $carbon = new \Carbon\Carbon('now');
+
+    $closure = function () use ($carbon) {
+        return $carbon;
+    };
+
+    $u = s($closure);
+    $r = $u();
+
+    expect($r)->toEqual($carbon);
+})->with('serializers');
+
+test('serializes carbon immutable objects', function () {
+    $carbon = new \Carbon\CarbonImmutable('now');
+
+    $closure = function () use ($carbon) {
+        return $carbon;
+    };
+
+    $u = s($closure);
+    $r = $u();
+
+    expect($r)->toEqual($carbon);
+})->with('serializers');
+
 class A
 {
     protected static function aStaticProtected()

--- a/tests/SerializerTest.php
+++ b/tests/SerializerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Carbon\Carbon;
+use Carbon\CarbonImmutable;
 use Laravel\SerializableClosure\SerializableClosure;
 use Laravel\SerializableClosure\Serializers\Signed;
 use Laravel\SerializableClosure\Support\ReflectionClosure;
@@ -401,31 +403,40 @@ test('from static callable namespaces', function () {
     expect($f(new Model))->toBeInstanceOf(Model::class);
 })->with('serializers');
 
-test('serializes carbon objects', function () {
-    $carbon = new \Carbon\Carbon('now');
-
-    $closure = function () use ($carbon) {
-        return $carbon;
+test('serializes used dates', function ($_, $date) {
+    $closure = function () use ($date) {
+        return $date;
     };
 
     $u = s($closure);
     $r = $u();
 
-    expect($r)->toEqual($carbon);
-})->with('serializers');
+    expect($r)->toEqual($date);
+})->with('serializers')->with([
+    new DateTime,
+    new DateTimeImmutable,
+    new Carbon,
+    new CarbonImmutable,
+]);
 
-test('serializes carbon immutable objects', function () {
-    $carbon = new \Carbon\CarbonImmutable('now');
+test('serializes with used object date properties', function ($_, $date) {
+    $obj = new ObjSelf;
+    $obj->o = $date;
 
-    $closure = function () use ($carbon) {
-        return $carbon;
+    $closure = function () use ($obj) {
+        return $obj;
     };
 
     $u = s($closure);
     $r = $u();
 
-    expect($r)->toEqual($carbon);
-})->with('serializers');
+    expect($r->o)->toEqual($date);
+})->with('serializers')->with([
+    new DateTime,
+    new DateTimeImmutable,
+    new Carbon,
+    new CarbonImmutable,
+]);
 
 class A
 {


### PR DESCRIPTION
This pull request is based on https://github.com/laravel/serializable-closure/pull/55, fixes the serialization of date carbon objects.