### PR TITLE
Skip readonly properties

### DIFF
--- a/src/Serializers/Native.php
+++ b/src/Serializers/Native.php
@@ -367,7 +367,7 @@ class Native implements Serializable
                 }
 
                 foreach ($reflection->getProperties() as $property) {
-                    if ($property->isStatic() || ! $property->getDeclaringClass()->isUserDefined()) {
+                    if ($property->isStatic() || (PHP_VERSION_ID >= 81000 && $property->isReadOnly()) || ! $property->getDeclaringClass()->isUserDefined()) {
                         continue;
                     }
 


### PR DESCRIPTION
The current will attempt to do `$property->setValue($data, $item)` which in the case of a readonly property will result into failure.

Having a glance at the tests it appears this should already be supported in theory, but I am running into this issue with `laravel/serializable-closure` v1.2.2 with [PHP-Scoper](https://github.com/humbug/php-scoper). So this needs deeper investigation