### PR TITLE
[1.x] Clarifies serialization on REPL environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ echo $closure(); // james;
 
 1. Creating **anonymous classes** within closures is not supported.
 2. Using attributes within closures is not supported.
+3. Serializing closures on REPL environments - such as Laravel Tinker - is not supported.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ echo $closure(); // james;
 
 1. Creating **anonymous classes** within closures is not supported.
 2. Using attributes within closures is not supported.
-3. Serializing closures on REPL environments - such as Laravel Tinker - is not supported.
+3. Serializing closures on REPL environments such as Laravel Tinker is not supported.
 
 ## Contributing
 


### PR DESCRIPTION
This pull request clarifies that is not possible to serialize closures on REPL environments.