### PR TITLE
feat: Add support for specifying if it should sign

### DIFF
--- a/src/UnsignedSerializableClosure.php
+++ b/src/UnsignedSerializableClosure.php
@@ -3,12 +3,9 @@
 namespace Laravel\SerializableClosure;
 
 use Closure;
-use Laravel\SerializableClosure\Exceptions\InvalidSignatureException;
 use Laravel\SerializableClosure\Exceptions\PhpVersionNotSupportedException;
-use Laravel\SerializableClosure\Serializers\Signed;
-use Laravel\SerializableClosure\Signers\Hmac;
 
-class SerializableClosure
+class UnsignedSerializableClosure
 {
     /**
      * The closure's serializable.
@@ -29,9 +26,7 @@ class SerializableClosure
             throw new PhpVersionNotSupportedException();
         }
 
-        $this->serializable = Serializers\Signed::$signer
-            ? new Serializers\Signed($closure)
-            : new Serializers\Native($closure);
+        $this->serializable = new Serializers\Native($closure);
     }
 
     /**
@@ -63,41 +58,6 @@ class SerializableClosure
     }
 
     /**
-     * Sets the serializable closure secret key.
-     *
-     * @param  string|null  $secret
-     * @return void
-     */
-    public static function setSecretKey($secret)
-    {
-        Serializers\Signed::$signer = $secret
-            ? new Hmac($secret)
-            : null;
-    }
-
-    /**
-     * Sets the serializable closure secret key.
-     *
-     * @param  \Closure|null  $transformer
-     * @return void
-     */
-    public static function transformUseVariablesUsing($transformer)
-    {
-        Serializers\Native::$transformUseVariables = $transformer;
-    }
-
-    /**
-     * Sets the serializable closure secret key.
-     *
-     * @param  \Closure|null  $resolver
-     * @return void
-     */
-    public static function resolveUseVariablesUsing($resolver)
-    {
-        Serializers\Native::$resolveUseVariables = $resolver;
-    }
-
-    /**
      * Get the serializable representation of the closure.
      *
      * @return array
@@ -114,15 +74,9 @@ class SerializableClosure
      *
      * @param  array  $data
      * @return void
-     *
-     * @throws \Laravel\SerializableClosure\Exceptions\InvalidSignatureException
      */
     public function __unserialize($data)
     {
-        if (Signed::$signer && ! $data['serializable'] instanceof Signed) {
-            throw new InvalidSignatureException();
-        }
-
         $this->serializable = $data['serializable'];
     }
 }


### PR DESCRIPTION
This adds a new parameter to specify if a closure should be signed or not.

## Why? 

When caching routes in the Laravel/framework, they are currently being cached signed. This means if you cache your routes and then set/change your `APP_KEY` your route caches are invalid.

This option allows the route caching logic to disable signing when caching the routes, which then means `APP_KEY` can be changed without the route caching being invalid.


## Usecase
When building a docker image it is currently impossible to cache your routes while building the image (if any routes are closures) as the `APP_KEY` should not be exposed to the build steps of the docker image.  

Caching the routes while building the image has a lot of advantages, as each instance does not have to cache it themselves. This can also prevent potential crashes of running out of storage when using k8s, as you cannot guarantee the amount of storage available outside of the image size unless you start mounting volumes etc. 



A PR will be created to `laravel/framework` for the needed changes there to utilize this new option.
https://github.com/laravel/framework/pull/45527