### PR TITLE
[1.x] Fixes and tests unsigned closures

### DIFF
--- a/src/SerializableClosure.php
+++ b/src/SerializableClosure.php
@@ -63,7 +63,7 @@ class SerializableClosure
     }
 
     /**
-     * Creates a new unsigned serializable closure instance.
+     * Create a new unsigned serializable closure instance.
      *
      * @param  Closure  $closure
      * @return \Laravel\SerializableClosure\UnsignedSerializableClosure

--- a/src/SerializableClosure.php
+++ b/src/SerializableClosure.php
@@ -63,6 +63,17 @@ class SerializableClosure
     }
 
     /**
+     * Creates a new unsigned serializable closure instance.
+     *
+     * @param  Closure  $closure
+     * @return \Laravel\SerializableClosure\UnsignedSerializableClosure
+     */
+    public static function unsigned(Closure $closure)
+    {
+        return new UnsignedSerializableClosure($closure);
+    }
+
+    /**
      * Sets the serializable closure secret key.
      *
      * @param  string|null  $secret

--- a/src/Serializers/Native.php
+++ b/src/Serializers/Native.php
@@ -10,6 +10,7 @@ use Laravel\SerializableClosure\Support\ClosureScope;
 use Laravel\SerializableClosure\Support\ClosureStream;
 use Laravel\SerializableClosure\Support\ReflectionClosure;
 use Laravel\SerializableClosure\Support\SelfReference;
+use Laravel\SerializableClosure\UnsignedSerializableClosure;
 use ReflectionObject;
 use UnitEnum;
 
@@ -379,7 +380,7 @@ class Native implements Serializable
 
                     $item = $property->getValue($data);
 
-                    if ($item instanceof SerializableClosure || ($item instanceof SelfReference && $item->hash === $this->code['self'])) {
+                    if ($item instanceof SerializableClosure || $item instanceof UnsignedSerializableClosure || ($item instanceof SelfReference && $item->hash === $this->code['self'])) {
                         $this->code['objects'][] = [
                             'instance' => $data,
                             'property' => $property,
@@ -452,7 +453,7 @@ class Native implements Serializable
             }
 
             unset($value);
-        } elseif (is_object($data) && ! $data instanceof SerializableClosure) {
+        } elseif (is_object($data) && ! $data instanceof SerializableClosure && ! $data instanceof UnsignedSerializableClosure) {
             if (isset($this->scope[$data])) {
                 $data = $this->scope[$data];
 

--- a/tests/Datasets/Serializers.php
+++ b/tests/Datasets/Serializers.php
@@ -1,10 +1,17 @@
 <?php
 
 use Laravel\SerializableClosure\Serializers;
+use Laravel\SerializableClosure\UnsignedSerializableClosure;
 
 dataset('serializers', function () {
-    foreach ([Serializers\Native::class, Serializers\Signed::class] as $serializer) {
-        yield (new ReflectionClass($serializer))->getShortName() => function () use ($serializer) {
+    foreach ([Serializers\Native::class, Serializers\Signed::class, UnsignedSerializableClosure::class] as $serializer) {
+        $serializerShortName = (new ReflectionClass($serializer))->getShortName();
+
+        if ($serializer != UnsignedSerializableClosure::class) {
+            $serializerShortName = 'SerializableClosure > '.$serializerShortName;
+        }
+
+        yield $serializerShortName => function () use ($serializer) {
             $this->serializer = $serializer;
         };
     }

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -3,6 +3,7 @@
 use Laravel\SerializableClosure\SerializableClosure;
 use Laravel\SerializableClosure\Serializers;
 use Laravel\SerializableClosure\Support\ReflectionClosure;
+use Laravel\SerializableClosure\UnsignedSerializableClosure;
 
 /*
 |--------------------------------------------------------------------------
@@ -68,6 +69,9 @@ function s($closure)
         case Serializers\Signed::class:
             SerializableClosure::setSecretKey('secret');
             $closure = new SerializableClosure($closure);
+            break;
+        case UnsignedSerializableClosure::class:
+            $closure = SerializableClosure::unsigned($closure);
             break;
         default:
             throw new Exception('Please use the [serializers] dataset.');

--- a/tests/Php73Test.php
+++ b/tests/Php73Test.php
@@ -3,8 +3,14 @@
 use Laravel\SerializableClosure\Exceptions\PhpVersionNotSupportedException;
 use Laravel\SerializableClosure\SerializableClosure;
 
-it('does not support PHP 7.3', function () {
+test('serializable closure does not support PHP 7.3', function () {
     new SerializableClosure(function () {
+        return 'foo';
+    });
+})->throws(PhpVersionNotSupportedException::class);
+
+test('unsigned serializable closure does not support PHP 7.3', function () {
+    SerializableClosure::unsigned(function () {
         return 'foo';
     });
 })->throws(PhpVersionNotSupportedException::class);


### PR DESCRIPTION
This pull request:

1. Runs the test suite against the new `UnsignedSerializableClosure`.
2. Lets `SerializableClosure` act as a factory and create `UnsignedSerializableClosure` using the static factory `SerializableClosure::unsigned`.
3. Fixes a bug in `src/Serializers/Native.php` where serializing `UnsignedSerializableClosure` could cause runtime exceptions if it had properties from the type `UnsignedSerializableClosure`.