### PR TITLE
Add test for namespace resolution in named parameters

### DIFF
--- a/src/Support/ReflectionClosure.php
+++ b/src/Support/ReflectionClosure.php
@@ -453,7 +453,6 @@ class ReflectionClosure extends ReflectionFunction
                         case T_NEW:
                         case T_STATIC:
                         case T_VARIABLE:
-                        case T_STRING:
                         case T_CLASS_C:
                         case T_FILE:
                         case T_DIR:
@@ -467,6 +466,16 @@ class ReflectionClosure extends ReflectionFunction
                         case T_USE:
                             $code .= $token[1];
                             $state = $lastState;
+                            break;
+                        case T_STRING:
+                            if ($context !== 'root' || $context === 'fetch') {
+                                $code .= $token[1];
+                                $state = $lastState;
+                                break;
+                            }
+
+                            $state = 'id_start';
+                            $i--;
                             break;
                         default:
                             $state = $lastState;
@@ -588,6 +597,8 @@ class ReflectionClosure extends ReflectionFunction
 
                             $code .= $id_start.$id_name.$token[1];
                             $state = $token[0] === T_DOUBLE_COLON ? 'ignore_next' : $lastState;
+                            // fetch for "Class::CONST"
+                            $context = $token[0] === T_DOUBLE_COLON ? 'fetch' : $context;
                             break;
                         default:
                             if ($id_start !== '\\' && ! defined($id_start)) {

--- a/tests/Fixtures/Sample.php
+++ b/tests/Fixtures/Sample.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Tests\Fixtures;
+
+class Sample {
+  public const C = 'CONST';
+  public function __construct($a1 = null, $a2 = null) {}
+}

--- a/tests/Fixtures/Sample.php
+++ b/tests/Fixtures/Sample.php
@@ -2,7 +2,11 @@
 
 namespace Tests\Fixtures;
 
-class Sample {
-  public const C = 'CONST';
-  public function __construct($a1 = null, $a2 = null) {}
+class Sample
+{
+    public const C = 'CONST';
+
+    public function __construct($a1 = null, $a2 = null)
+    {
+    }
 }

--- a/tests/SerializerPhp80Test.php
+++ b/tests/SerializerPhp80Test.php
@@ -1,5 +1,7 @@
 <?php
 
+use Tests\Fixtures\Sample;
+
 test('named arguments', function () {
     $f1 = function (string $firstName, string $lastName) {
         return $firstName.' '.$lastName;
@@ -41,6 +43,14 @@ test('multiple named arguments within nested closures', function () {
     };
 
     expect('string1')->toBe(s($f1)());
+})->with('serializers');
+
+test('named arguments with namespaced parameter', function () {
+    $f1 = function () {
+        return new Sample(a2: Sample::C);
+    };
+
+    expect(s($f1)())->toBeInstanceOf(Sample::class);
 })->with('serializers');
 
 class SerializerPhp80NamedArguments


### PR DESCRIPTION
This PR includes a failing test for #66 as requested by @nunomaduro :-)

In the test, a public constant from a FQCN is passed as a named argument inside a closure.
During serialization, the class namespace gets resolved for all places where it appears, except for the parameter, causing an error when the closure gets deserialized/called.
