### PR TITLE
Added test for readonly properties from parent scope variable

### DIFF
--- a/tests/ReflectionClosurePhp81Test.php
+++ b/tests/ReflectionClosurePhp81Test.php
@@ -123,6 +123,20 @@ test('readonly properties', function () {
     expect($f)->toBeCode($e);
 });
 
+test('readonly properties from parent scope variable', function () {
+    $controller = new SerializerPhp81Controller();
+
+    $f = static function () use($controller) {
+        return $controller;
+    };
+
+    $f = s($f);
+
+    expect($f()->service)->toBeInstanceOf(
+        SerializerPhp81Service::class,
+    );
+})->with('serializers');
+
 test('first-class callable with closures', function () {
     $f = function ($a) {
         $f = fn ($b) => $a + $b + 1;


### PR DESCRIPTION
This PR adds a failing test for #58.

In the test, the closure inherits an object which uses readonly properties from the parent scope. 
This causes an error when the closure gets deserialised as explained by @theofidry.
