### PR TITLE
[1.x] Adds documentation about `readonly` caveat

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,10 @@ echo $closure(); // james;
 
 ### Caveats
 
-1. Creating **anonymous classes** within closures is not supported.
-2. Using attributes within closures is not supported.
-3. Serializing closures on REPL environments such as Laravel Tinker is not supported.
+* Anonymous classes cannot be created within closures.
+* Attributes cannot be used within closures.
+* erializing closures on REPL environments like Laravel Tinker is not supported.
+* Serializing closures that reference objects with readonly properties is not supported.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ echo $closure(); // james;
 
 * Anonymous classes cannot be created within closures.
 * Attributes cannot be used within closures.
-* erializing closures on REPL environments like Laravel Tinker is not supported.
+* Serializing closures on REPL environments like Laravel Tinker is not supported.
 * Serializing closures that reference objects with readonly properties is not supported.
 
 ## Contributing


### PR DESCRIPTION
This pull request adds documentation about `readonly` caveat.