### PR TITLE
[1.x] Fixes FQCN on anonymous classes definition 

### DIFF
--- a/src/Support/ReflectionClosure.php
+++ b/src/Support/ReflectionClosure.php
@@ -642,6 +642,11 @@ class ReflectionClosure extends ReflectionFunction
                     break;
                 case 'anonymous':
                     switch ($token[0]) {
+                        case T_NAME_QUALIFIED:
+                            [$id_start, $id_start_ci, $id_name] = $this->parseNameQualified($token[1]);
+                            $state = 'id_name';
+                            $lastState = 'anonymous';
+                            break 2;
                         case T_NS_SEPARATOR:
                         case T_STRING:
                             $id_start = $token[1];

--- a/tests/ReflectionClosure5Test.php
+++ b/tests/ReflectionClosure5Test.php
@@ -65,6 +65,58 @@ test('resolve types', function () {
     $f7 = fn () => new class implements Baz\Qux, Baz\Qux {};
     $e7 = 'fn () => new class implements \Foo\Bar\Qux, \Foo\Bar\Qux {}';
 
+    $f8 = function () {
+        $a = new class implements Baz\Qux, Baz\Qux {};
+
+        $b = new class implements Baz\Qux {};
+    };
+
+    $e8 = 'function () {
+        $a = new class implements \Foo\Bar\Qux, \Foo\Bar\Qux {};
+
+        $b = new class implements \Foo\Bar\Qux {};
+    }';
+
+    $f9 = function () {
+        $a = new class implements Baz\Qux, Baz\Qux {};
+
+        $b = new class extends Forest implements Baz\Qux {
+            public Baz\Qux $qux;
+
+            public function foo()
+            {
+                return new class {};
+            }
+
+            public function qux(Baz\Qux $qux): Baz\Qux
+            {
+                return static fn () => new class extends Forest implements Baz\Qux {
+                    //
+                };
+            }
+        };
+    };
+
+    $e9 = 'function () {
+        $a = new class implements \Foo\Bar\Qux, \Foo\Bar\Qux {};
+
+        $b = new class extends \Foo\Baz\Qux\Forest implements \Foo\Bar\Qux {
+            public \Foo\Bar\Qux $qux;
+
+            public function foo()
+            {
+                return new class {};
+            }
+
+            public function qux(\Foo\Bar\Qux $qux): \Foo\Bar\Qux
+            {
+                return static fn () => new class extends \Foo\Baz\Qux\Forest implements \Foo\Bar\Qux {
+                    //
+                };
+            }
+        };
+    }';
+
     expect($f1)->toBeCode($e1);
     expect($f2)->toBeCode($e2);
     expect($f3)->toBeCode($e3);
@@ -72,6 +124,8 @@ test('resolve types', function () {
     expect($f5)->toBeCode($e5);
     expect($f6)->toBeCode($e6);
     expect($f7)->toBeCode($e7);
+    expect($f8)->toBeCode($e8);
+    expect($f9)->toBeCode($e9);
 });
 
 test('class keywords instantiation', function () {

--- a/tests/ReflectionClosure5Test.php
+++ b/tests/ReflectionClosure5Test.php
@@ -56,10 +56,22 @@ test('resolve types', function () {
     $f4 = fn () => new Qux();
     $e4 = 'fn () => new \Foo\Baz\Qux()';
 
+    $f5 = fn () => new class extends Baz\Qux {};
+    $e5 = 'fn () => new class extends \Foo\Bar\Qux {}';
+
+    $f6 = fn () => new class extends Baz\Qux implements Baz\Qux {};
+    $e6 = 'fn () => new class extends \Foo\Bar\Qux implements \Foo\Bar\Qux {}';
+
+    $f7 = fn () => new class implements Baz\Qux, Baz\Qux {};
+    $e7 = 'fn () => new class implements \Foo\Bar\Qux, \Foo\Bar\Qux {}';
+
     expect($f1)->toBeCode($e1);
     expect($f2)->toBeCode($e2);
     expect($f3)->toBeCode($e3);
     expect($f4)->toBeCode($e4);
+    expect($f5)->toBeCode($e5);
+    expect($f6)->toBeCode($e6);
+    expect($f7)->toBeCode($e7);
 });
 
 test('class keywords instantiation', function () {

--- a/tests/ReflectionClosure5Test.php
+++ b/tests/ReflectionClosure5Test.php
@@ -101,7 +101,8 @@ test('resolve types', function () {
     $e9 = 'function () {
         $a = new class implements \Foo\Bar\Qux, \Foo\Bar\Qux {};
 
-        $b = new class extends \Foo\Baz\Qux\Forest implements \Foo\Bar\Qux {
+        $b = new class extends \Foo\Baz\Qux\Forest implements \Foo\Bar\Qux
+        {
             public \Foo\Bar\Qux $qux;
 
             public function foo()

--- a/tests/ReflectionClosure5Test.php
+++ b/tests/ReflectionClosure5Test.php
@@ -80,7 +80,8 @@ test('resolve types', function () {
     $f9 = function () {
         $a = new class implements Baz\Qux, Baz\Qux {};
 
-        $b = new class extends Forest implements Baz\Qux {
+        $b = new class extends Forest implements Baz\Qux
+        {
             public Baz\Qux $qux;
 
             public function foo()


### PR DESCRIPTION
This pull request fixes the usage of FQCN on anonymous classes definition. It contains the contents of https://github.com/laravel/serializable-closure/pull/74, but I've added some more tests. 