### PR TITLE
Add tests for laravel/serializable-closure#78

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -24,6 +24,7 @@
             <file phpVersion="7.4.0" phpVersionOperator=">=">./tests/ReflectionClosure3Test.php</file>
             <file phpVersion="7.4.0" phpVersionOperator=">=">./tests/ReflectionClosure4Test.php</file>
             <file phpVersion="7.4.0" phpVersionOperator=">=">./tests/ReflectionClosure5Test.php</file>
+            <file phpVersion="7.4.0" phpVersionOperator=">=">./tests/SwitchCaseInstanceofClosureTest.php</file>
         </testsuite>
         <testsuite name="php80">
             <file phpVersion="8.0.0-dev" phpVersionOperator=">=">./tests/ReflectionClosurePhp80Test.php</file>

--- a/tests/SwitchCaseInstanceofClosureTest.php
+++ b/tests/SwitchCaseInstanceofClosureTest.php
@@ -1,6 +1,6 @@
 <?php
 
-test('closure with switch', function () {
+test('closure with switch containing an instanceof case', function () {
     $c = function () {
         $var = new \stdClass();
 

--- a/tests/SwitchClosureTest.php
+++ b/tests/SwitchClosureTest.php
@@ -1,0 +1,19 @@
+<?php
+
+test('closure with switch', function () {
+    $c = function () {
+        $var = new \stdClass();
+
+        switch(true) {
+            case $var instanceof \stdClass:
+                return true;
+
+            default:
+                return false;
+        }
+    };
+
+    $u = s($c)();
+
+    expect($u)->toBe(true);
+})->with('serializers');


### PR DESCRIPTION
### Serializable Closure Version

1.3.2

### PHP Version

8.2

### Description

It seems that when there is a `switch` statement that contains a class reference the namespace resolution that happens during serialization causes the colon to be removed at the end of the `case` line, steps to reproduce contains a CLI command to replicate this behavior.

```
syntax error, unexpected token "return"
```

### Steps To Reproduce

```
<?php

namespace App\Console\Commands;

use Illuminate\Console\Command;
use Laravel\SerializableClosure\Serializers\Native;

class DebugCommand extends Command
{
    /**
     * The name and signature of the console command.
     *
     * @var string
     */
    protected $signature = 'debug';

    /**
     * The console command description.
     *
     * @var string
     */
    protected $description = 'Command description';

    /**
     * Execute the console command.
     */
    public function handle()
    {
        $cacheClosure = static function(): array {
            $var = new \stdClass();

            switch(true) {
                case $var instanceof \stdClass:
                    return true;

                default:
                    return false;
            }
        };

        $cacheData = [
           'helloWorld' =>  $cacheClosure
        ];

        Native::wrapClosures($cacheData, new \SplObjectStorage());
        $cacheContent = serialize($cacheData);

        dump($cacheContent);exit;

        unserialize($cacheContent);exit;
    }
}
```