### PR TITLE
[1.x] Fixes switch cases namespace resolution

### DIFF
--- a/src/Support/ReflectionClosure.php
+++ b/src/Support/ReflectionClosure.php
@@ -511,7 +511,6 @@ class ReflectionClosure extends ReflectionFunction
                         case $token[0] === ':' && $context !== 'instanceof':
                             if ($lastState === 'closure' && $context === 'root') {
                                 $state = 'closure';
-
                                 $code .= $id_start.$token;
                             }
 

--- a/src/Support/ReflectionClosure.php
+++ b/src/Support/ReflectionClosure.php
@@ -508,9 +508,10 @@ class ReflectionClosure extends ReflectionFunction
                     break;
                 case 'id_name':
                     switch ($token[0]) {
-                        case ':':
-                            if ($lastState === 'closure' && in_array($context, ['root', 'instanceof'], true)) {
+                        case $token[0] === ':' && $context !== 'instanceof':
+                            if ($lastState === 'closure' && $context === 'root') {
                                 $state = 'closure';
+
                                 $code .= $id_start.$token;
                             }
 

--- a/src/Support/ReflectionClosure.php
+++ b/src/Support/ReflectionClosure.php
@@ -508,9 +508,8 @@ class ReflectionClosure extends ReflectionFunction
                     break;
                 case 'id_name':
                     switch ($token[0]) {
-                        // named arguments...
                         case ':':
-                            if ($lastState === 'closure' && $context === 'root') {
+                            if ($lastState === 'closure' && in_array($context, ['root', 'instanceof'], true)) {
                                 $state = 'closure';
                                 $code .= $id_start.$token;
                             }

--- a/tests/ReflectionClosure1Test.php
+++ b/tests/ReflectionClosure1Test.php
@@ -329,8 +329,10 @@ test('instanceof', function () {
 
         return [
             $b,
-            ($a instanceof \DateTime || $a instanceof \ReflectionClosurePhp74InstanceOfTest || $a instanceof \Tests\Fixtures\RegularClass),
-            (function ($a) { return ($a instanceof \DateTime || $a instanceof \ReflectionClosurePhp74InstanceOfTest || $a instanceof \Tests\Fixtures\RegularClass) === true; })($a),
+            $a instanceof \DateTime || $a instanceof \ReflectionClosurePhp74InstanceOfTest || $a instanceof \Tests\Fixtures\RegularClass,
+            (function ($a) {
+                return ($a instanceof \DateTime || $a instanceof \ReflectionClosurePhp74InstanceOfTest || $a instanceof \Tests\Fixtures\RegularClass) === true;
+            })($a),
         ];
     }';
 

--- a/tests/ReflectionClosure1Test.php
+++ b/tests/ReflectionClosure1Test.php
@@ -305,7 +305,7 @@ function reflection_closure_php_74_switch_statement_test_is_two($a)
 
 class ReflectionClosurePhp74InstanceOfTest
 {
-};
+}
 
 class ReflectionClosurePhp74SwitchStatementTest
 {
@@ -317,8 +317,10 @@ test('instanceof', function () {
 
         return [
             $b,
-            ($a instanceof DateTime || $a instanceof ReflectionClosurePhp74InstanceOfTest || $a instanceof RegularClass),
-            (function ($a) { return ($a instanceof DateTime || $a instanceof ReflectionClosurePhp74InstanceOfTest || $a instanceof RegularClass) === true; })($a),
+            $a instanceof DateTime || $a instanceof ReflectionClosurePhp74InstanceOfTest || $a instanceof RegularClass,
+            (function ($a) {
+                return ($a instanceof DateTime || $a instanceof ReflectionClosurePhp74InstanceOfTest || $a instanceof RegularClass) === true;
+            })($a),
         ];
     };
 

--- a/tests/ReflectionClosure1Test.php
+++ b/tests/ReflectionClosure1Test.php
@@ -297,3 +297,86 @@ test('consts', function () {
 
     expect($f1)->toBeCode($e1);
 });
+
+function reflection_closure_php_74_switch_statement_test_is_two($a)
+{
+    return $a === 2;
+}
+
+class ReflectionClosurePhp74InstanceOfTest
+{
+};
+
+class ReflectionClosurePhp74SwitchStatementTest
+{
+}
+
+test('instanceof', function () {
+    $f1 = function ($a) {
+        $b = $a instanceof DateTime || $a instanceof ReflectionClosurePhp74InstanceOfTest || $a instanceof RegularClass;
+
+        return [
+            $b,
+            ($a instanceof DateTime || $a instanceof ReflectionClosurePhp74InstanceOfTest || $a instanceof RegularClass),
+            (function ($a) { return ($a instanceof DateTime || $a instanceof ReflectionClosurePhp74InstanceOfTest || $a instanceof RegularClass) === true; })($a),
+        ];
+    };
+
+    $e1 = 'function ($a) {
+        $b = $a instanceof \DateTime || $a instanceof \ReflectionClosurePhp74InstanceOfTest || $a instanceof \Tests\Fixtures\RegularClass;
+
+        return [
+            $b,
+            ($a instanceof \DateTime || $a instanceof \ReflectionClosurePhp74InstanceOfTest || $a instanceof \Tests\Fixtures\RegularClass),
+            (function ($a) { return ($a instanceof \DateTime || $a instanceof \ReflectionClosurePhp74InstanceOfTest || $a instanceof \Tests\Fixtures\RegularClass) === true; })($a),
+        ];
+    }';
+
+    expect($f1)->toBeCode($e1);
+});
+
+test('switch statement', function () {
+    $f1 = function ($a) {
+        switch (true) {
+            case $a === 1:
+                return 'one';
+            case reflection_closure_php_74_switch_statement_test_is_two($a):
+                return 'two';
+            case ReflectionClosurePhp74SwitchStatementTest::isThree($a):
+                return 'three';
+            case (new ReflectionClosurePhp74SwitchStatementTest)->isFour($a):
+                return 'four';
+            case $a instanceof ReflectionClosurePhp74SwitchStatementTest:
+                return 'five';
+            case $a instanceof DateTime:
+                return 'six';
+            case $a instanceof RegularClass:
+                return 'seven';
+            default:
+                return 'other';
+        }
+    };
+
+    $e1 = 'function ($a) {
+        switch (true) {
+            case $a === 1:
+                return \'one\';
+            case \reflection_closure_php_74_switch_statement_test_is_two($a):
+                return \'two\';
+            case \ReflectionClosurePhp74SwitchStatementTest::isThree($a):
+                return \'three\';
+            case (new \ReflectionClosurePhp74SwitchStatementTest)->isFour($a):
+                return \'four\';
+            case $a instanceof \ReflectionClosurePhp74SwitchStatementTest:
+                return \'five\';
+            case $a instanceof \DateTime:
+                return \'six\';
+            case $a instanceof \Tests\Fixtures\RegularClass:
+                return \'seven\';
+            default:
+                return \'other\';
+        }
+    }';
+
+    expect($f1)->toBeCode($e1);
+});

--- a/tests/ReflectionClosurePhp80Test.php
+++ b/tests/ReflectionClosurePhp80Test.php
@@ -87,7 +87,7 @@ test('named arguments', function () {
     }";
 
     expect($f1)->toBeCode($e1);
-})->with('serializers');
+});
 
 test('single named argument within closures', function () {
     $f1 = function () {
@@ -99,7 +99,7 @@ test('single named argument within closures', function () {
     }";
 
     expect($f1)->toBeCode($e1);
-})->with('serializers');
+});
 
 test('multiple named arguments within closures', function () {
     $f1 = function () {
@@ -111,7 +111,29 @@ test('multiple named arguments within closures', function () {
     }";
 
     expect($f1)->toBeCode($e1);
-})->with('serializers');
+});
+
+test('named arguments with switch cases and instanceof', function () {
+    $f1 = function ($a) {
+        switch (true) {
+            case (new RegularClass(a2: $a))->a2 instanceof RegularClass:
+                return (new RegularClass(a2: $a))->a2;
+            default:
+                return new RegularClass(a2: RegularClass::C);
+        }
+    };
+
+    $e1 = 'function ($a) {
+        switch (true) {
+            case (new \Tests\Fixtures\RegularClass(a2: $a))->a2 instanceof \Tests\Fixtures\RegularClass:
+                return (new \Tests\Fixtures\RegularClass(a2: $a))->a2;
+            default:
+                return new \Tests\Fixtures\RegularClass(a2: \Tests\Fixtures\RegularClass::C);
+        }
+    }';
+
+    expect($f1)->toBeCode($e1);
+});
 
 test('multiple named arguments within nested closures', function () {
     $f1 = function () {

--- a/tests/ReflectionClosurePhp80Test.php
+++ b/tests/ReflectionClosurePhp80Test.php
@@ -2,6 +2,7 @@
 
 // Fake
 use Some\ClassName as ClassAlias;
+use Tests\Fixtures\RegularClass;
 
 test('union types', function () {
     $f1 = fn (): string|int|false|Bar|null => 1;
@@ -159,3 +160,138 @@ class PropertyPromotion
         return $this->private;
     }
 }
+
+function reflection_closure_php_80_switch_statement_test_is_two($a)
+{
+    return $a === 2;
+}
+
+class ReflectionClosurePhp80InstanceOfTest
+{
+};
+
+class ReflectionClosurePhp80SwitchStatementTest
+{
+}
+
+test('instanceof', function () {
+    $f1 = function (object $a): array {
+        $b = $a instanceof DateTime || $a instanceof ReflectionClosurePhp80InstanceOfTest || $a instanceof RegularClass;
+
+        return [
+            $b,
+            ($a instanceof DateTime || $a instanceof ReflectionClosurePhp80InstanceOfTest || $a instanceof RegularClass),
+            (function (object $a): bool {
+                return ($a instanceof DateTime || $a instanceof ReflectionClosurePhp80InstanceOfTest || $a instanceof RegularClass) === true;
+            })(a: $a),
+        ];
+    };
+
+    $e1 = 'function (object $a): array {
+        $b = $a instanceof \DateTime || $a instanceof \ReflectionClosurePhp80InstanceOfTest || $a instanceof \Tests\Fixtures\RegularClass;
+
+        return [
+            $b,
+            ($a instanceof \DateTime || $a instanceof \ReflectionClosurePhp80InstanceOfTest || $a instanceof \Tests\Fixtures\RegularClass),
+            (function (object $a): bool {
+                return ($a instanceof \DateTime || $a instanceof \ReflectionClosurePhp80InstanceOfTest || $a instanceof \Tests\Fixtures\RegularClass) === true;
+            })(a: $a),
+        ];
+    }';
+
+    expect($f1)->toBeCode($e1);
+});
+
+test('switch statement', function () {
+    $f1 = function ($a) {
+        switch (true) {
+            case $a === 1:
+                return 'one';
+            case reflection_closure_php_80_switch_statement_test_is_two(a: $a):
+                return 'two';
+            case ReflectionClosurePhp80SwitchStatementTest::isThree(a: $a):
+                return 'three';
+            case (new ReflectionClosurePhp80SwitchStatementTest)->isFour(a: $a):
+                return 'four';
+            case ($a instanceof ReflectionClosurePhp80SwitchStatementTest):
+                return 'five';
+            case ($a instanceof DateTime):
+                return 'six';
+            case ($a instanceof RegularClass):
+                return 'seven';
+            default:
+                return 'other';
+        }
+    };
+
+    $e1 = 'function ($a) {
+        switch (true) {
+            case $a === 1:
+                return \'one\';
+            case \reflection_closure_php_80_switch_statement_test_is_two(a: $a):
+                return \'two\';
+            case \ReflectionClosurePhp80SwitchStatementTest::isThree(a: $a):
+                return \'three\';
+            case (new \ReflectionClosurePhp80SwitchStatementTest)->isFour(a: $a):
+                return \'four\';
+            case ($a instanceof \ReflectionClosurePhp80SwitchStatementTest):
+                return \'five\';
+            case ($a instanceof \DateTime):
+                return \'six\';
+            case ($a instanceof \Tests\Fixtures\RegularClass):
+                return \'seven\';
+            default:
+                return \'other\';
+        }
+    }';
+
+    expect($f1)->toBeCode($e1);
+});
+
+function reflection_closure_php_80_match_statement_test_is_two($a)
+{
+    return $a === 2;
+}
+
+class ReflectionClosurePhp80MatchStatementTest
+{
+    public static function isThree($a)
+    {
+        return $a === 3;
+    }
+
+    public function isFour($a)
+    {
+        return $a === 4;
+    }
+}
+
+test('match statement', function () {
+    $f1 = function ($a) {
+        return match (true) {
+            $a === 1 => 'one',
+            reflection_closure_php_80_match_statement_test_is_two($a) => 'two',
+            ReflectionClosurePhp80MatchStatementTest::isThree(a: $a) => 'three',
+            (new ReflectionClosurePhp80MatchStatementTest)->isFour($a) => 'four',
+            $a instanceof ReflectionClosurePhp80MatchStatementTest => 'five',
+            $a instanceof DateTime => 'six',
+            $a instanceof RegularClass => 'seven',
+            default => 'other',
+        };
+    };
+
+    $e1 = 'function ($a) {
+        return match (true) {
+            $a === 1 => \'one\',
+            \reflection_closure_php_80_match_statement_test_is_two($a) => \'two\',
+            \ReflectionClosurePhp80MatchStatementTest::isThree(a: $a) => \'three\',
+            (new \ReflectionClosurePhp80MatchStatementTest)->isFour($a) => \'four\',
+            $a instanceof \ReflectionClosurePhp80MatchStatementTest => \'five\',
+            $a instanceof \DateTime => \'six\',
+            $a instanceof \Tests\Fixtures\RegularClass => \'seven\',
+            default => \'other\',
+        };
+    }';
+
+    expect($f1)->toBeCode($e1);
+});

--- a/tests/ReflectionClosurePhp81Test.php
+++ b/tests/ReflectionClosurePhp81Test.php
@@ -146,6 +146,7 @@ test('named arguments', function () {
             a20: reflection_closure_my_function(enum: ReflectionClosureGlobalEnum::Guest),
             a21: match (true) {
                 true => new RegularClass(),
+                false => (new RegularClass()) instanceof RegularClass,
                 default => reflection_closure_my_function(enum: ReflectionClosureGlobalEnum::Guest),
             },
         );
@@ -282,6 +283,7 @@ test('named arguments', function () {
             a20: \\reflection_closure_my_function(enum: \ReflectionClosureGlobalEnum::Guest),
             a21: match (true) {
                 true => new \Tests\Fixtures\RegularClass(),
+                false => (new \Tests\Fixtures\RegularClass()) instanceof \Tests\Fixtures\RegularClass,
                 default => \\reflection_closure_my_function(enum: \ReflectionClosureGlobalEnum::Guest),
             },
         );

--- a/tests/ReflectionClosurePhp81Test.php
+++ b/tests/ReflectionClosurePhp81Test.php
@@ -144,6 +144,10 @@ test('named arguments', function () {
             a18: reflection_closure_my_function(),
             a19: reflection_closure_my_function(ReflectionClosureGlobalEnum::Guest),
             a20: reflection_closure_my_function(enum: ReflectionClosureGlobalEnum::Guest),
+            a21: match (true) {
+                true => new RegularClass(),
+                default => reflection_closure_my_function(enum: ReflectionClosureGlobalEnum::Guest),
+            },
         );
     };
 
@@ -276,6 +280,10 @@ test('named arguments', function () {
             a18: \\reflection_closure_my_function(),
             a19: \\reflection_closure_my_function(\ReflectionClosureGlobalEnum::Guest),
             a20: \\reflection_closure_my_function(enum: \ReflectionClosureGlobalEnum::Guest),
+            a21: match (true) {
+                true => new \Tests\Fixtures\RegularClass(),
+                default => \\reflection_closure_my_function(enum: \ReflectionClosureGlobalEnum::Guest),
+            },
         );
     }";
 

--- a/tests/SerializerPhp80Test.php
+++ b/tests/SerializerPhp80Test.php
@@ -123,7 +123,7 @@ test('switch statement', function () {
         switch (true) {
             case $a === 1:
                 return 'one';
-            case serializer_php_74_switch_statement_test_is_two(a: $a):
+            case serializer_php_80_switch_statement_test_is_two(a: $a):
                 return 'two';
             case SerializerPhp80SwitchStatementClass::isThree(a: $a):
                 return 'three';
@@ -149,12 +149,12 @@ test('switch statement', function () {
         ->and($u(999))->toEqual('other');
 })->with('serializers');
 
-function match_statement_test_is_two($a)
+function serializer_php_80_match_statement_test_is_two($a)
 {
     return $a === 2;
 }
 
-class MatchStatementClass
+class SerializerPhp80MatchStatementTest
 {
     public static function isThree($a)
     {
@@ -171,10 +171,10 @@ test('match statement', function () {
     $closure = function ($a) {
         return match (true) {
             $a === 1 => 'one',
-            match_statement_test_is_two($a) => 'two',
-            MatchStatementClass::isThree($a) => 'three',
-            (new MatchStatementClass)->isFour(a: $a) => 'four',
-            $a instanceof MatchStatementClass => 'five',
+            serializer_php_80_match_statement_test_is_two($a) => 'two',
+            SerializerPhp80MatchStatementTest::isThree($a) => 'three',
+            (new SerializerPhp80MatchStatementTest)->isFour(a: $a) => 'four',
+            $a instanceof SerializerPhp80MatchStatementTest => 'five',
             $a instanceof DateTime => 'six',
             default => 'other',
         };
@@ -186,7 +186,7 @@ test('match statement', function () {
         ->and($u(2))->toEqual('two')
         ->and($u(3))->toEqual('three')
         ->and($u(4))->toEqual('four')
-        ->and($u(new MatchStatementClass))->toEqual('five')
+        ->and($u(new SerializerPhp80MatchStatementTest))->toEqual('five')
         ->and($u(new DateTime))->toEqual('six')
         ->and($u(999))->toEqual('other');
 })->with('serializers');

--- a/tests/SerializerPhp80Test.php
+++ b/tests/SerializerPhp80Test.php
@@ -177,6 +177,7 @@ test('match statement', function () {
             (new SerializerPhp80MatchStatementTest)->isFour(a: $a) => 'four',
             $a instanceof SerializerPhp80MatchStatementTest => 'five',
             $a instanceof DateTime => 'six',
+            $a instanceof RegularClass => 'seven',
             default => 'other',
         };
     };
@@ -189,5 +190,6 @@ test('match statement', function () {
         ->and($u(4))->toEqual('four')
         ->and($u(new SerializerPhp80MatchStatementTest))->toEqual('five')
         ->and($u(new DateTime))->toEqual('six')
+        ->and($u(new RegularClass))->toEqual('seven')
         ->and($u(999))->toEqual('other');
 })->with('serializers');

--- a/tests/SerializerPhp80Test.php
+++ b/tests/SerializerPhp80Test.php
@@ -80,7 +80,7 @@ class SerializerPhp80NamedArguments
 function match_statement_test_is_two($a)
 {
     return $a === 2;
-};
+}
 
 class MatchStatementClass
 {
@@ -97,7 +97,7 @@ class MatchStatementClass
 
 test('match statement', function () {
     $closure = function ($a) {
-        return match(true) {
+        return match (true) {
             $a === 1 => 'one',
             match_statement_test_is_two($a) => 'two',
             MatchStatementClass::isThree($a) => 'three',

--- a/tests/SerializerPhp80Test.php
+++ b/tests/SerializerPhp80Test.php
@@ -76,3 +76,45 @@ class SerializerPhp80NamedArguments
         return $namedArgument.(string) $namedArgumentB;
     }
 }
+
+function match_statement_test_is_two($a)
+{
+    return $a === 2;
+};
+
+class MatchStatementClass
+{
+    public static function isThree($a)
+    {
+        return $a === 3;
+    }
+
+    public function isFour($a)
+    {
+        return $a === 4;
+    }
+}
+
+test('match statement', function () {
+    $closure = function ($a) {
+        return match(true) {
+            $a === 1 => 'one',
+            match_statement_test_is_two($a) => 'two',
+            MatchStatementClass::isThree($a) => 'three',
+            (new MatchStatementClass)->isFour($a) => 'four',
+            $a instanceof MatchStatementClass => 'five',
+            $a instanceof DateTime => 'six',
+            default => 'other',
+        };
+    };
+
+    $u = s($closure);
+
+    expect($u(1))->toEqual('one')
+        ->and($u(2))->toEqual('two')
+        ->and($u(3))->toEqual('three')
+        ->and($u(4))->toEqual('four')
+        ->and($u(new MatchStatementClass))->toEqual('five')
+        ->and($u(new DateTime))->toEqual('six')
+        ->and($u(999))->toEqual('other');
+})->with('serializers');

--- a/tests/SerializerPhp80Test.php
+++ b/tests/SerializerPhp80Test.php
@@ -78,6 +78,23 @@ test('named arguments with match statements', function () {
         ->and($instance->a2)->toBeNull();
 })->with('serializers');
 
+test('named arguments with switch cases and instanceof', function () {
+    $f1 = function ($a) {
+        switch (true) {
+            case (new RegularClass(a2: $a))->a2 instanceof RegularClass:
+                return (new RegularClass(a2: $a))->a2;
+            default:
+                return new DateTime();
+        }
+    };
+
+    $instance = s($f1)('anything');
+    expect($instance)->toBeInstanceOf(DateTime::class);
+
+    $instance = s($f1)(new RegularClass());
+    expect($instance)->toBeInstanceOf(RegularClass::class);
+})->with('serializers');
+
 test('named arguments with namespaced class instance parameter', function () {
     $f1 = function () {
         return new RegularClass(a2: new RegularClass());

--- a/tests/SerializerPhp80Test.php
+++ b/tests/SerializerPhp80Test.php
@@ -57,6 +57,27 @@ test('named arguments with namespaced class const parameter', function () {
         ->and($instance->a2)->toBe('CONST');
 })->with('serializers');
 
+test('named arguments with match statements', function () {
+    $f1 = function ($a) {
+        return new RegularClass(a2: match($a) {
+            1 => RegularClass::C,
+            2 => null,
+        });
+    };
+
+    $instance = s($f1)(1);
+
+    expect($instance)->toBeInstanceOf(RegularClass::class)
+        ->and($instance->a1)->toBeNull()
+        ->and($instance->a2)->toBe('CONST');
+
+    $instance = s($f1)(2);
+
+    expect($instance)->toBeInstanceOf(RegularClass::class)
+        ->and($instance->a1)->toBeNull()
+        ->and($instance->a2)->toBeNull();
+})->with('serializers');
+
 test('named arguments with namespaced class instance parameter', function () {
     $f1 = function () {
         return new RegularClass(a2: new RegularClass());

--- a/tests/SerializerPhp80Test.php
+++ b/tests/SerializerPhp80Test.php
@@ -77,6 +77,78 @@ class SerializerPhp80NamedArguments
     }
 }
 
+function serializer_php_80_switch_statement_test_is_two($a)
+{
+    return $a === 2;
+}
+
+class SerializerPhp80SwitchStatementClass
+{
+    public static function isThree($a)
+    {
+        return $a === 3;
+    }
+
+    public function isFour($a)
+    {
+        return $a === 4;
+    }
+}
+
+class SerializerPhp80Class {};
+
+test('instanceof', function () {
+    $closure = function (object $a): array {
+        $b = $a instanceof DateTime || $a instanceof SerializerPhp80Class;
+
+        return [
+            $b,
+            ($a instanceof DateTime || $a instanceof SerializerPhp80Class),
+            (function (object $a): bool {
+                return ($a instanceof DateTime || $a instanceof SerializerPhp80Class) === true;
+            })(a: $a),
+        ];
+
+    };
+
+    $u = s($closure);
+
+    expect($u(new DateTime))->toEqual([true, true, true])
+        ->and($u(new SerializerPhp80Class))->toEqual([true, true, true])
+        ->and($u(new stdClass))->toEqual([false, false, false]);
+})->with('serializers');
+
+test('switch statement', function () {
+    $closure = function ($a) {
+        switch (true) {
+            case $a === 1:
+                return 'one';
+            case serializer_php_74_switch_statement_test_is_two(a: $a):
+                return 'two';
+            case SerializerPhp80SwitchStatementClass::isThree(a: $a):
+                return 'three';
+            case (new SerializerPhp80SwitchStatementClass)->isFour(a: $a):
+                return 'four';
+            case ($a instanceof SerializerPhp80SwitchStatementClass):
+                return 'five';
+            case ($a instanceof DateTime):
+                return 'six';
+            default:
+                return 'other';
+        }
+    };
+
+    $u = s($closure);
+
+    expect($u(1))->toEqual('one')
+        ->and($u(2))->toEqual('two')
+        ->and($u(3))->toEqual('three')
+        ->and($u(4))->toEqual('four')
+        ->and($u(new SerializerPhp80SwitchStatementClass))->toEqual('five')
+        ->and($u(new DateTime))->toEqual('six')
+        ->and($u(999))->toEqual('other');
+})->with('serializers');
+
 function match_statement_test_is_two($a)
 {
     return $a === 2;
@@ -101,7 +173,7 @@ test('match statement', function () {
             $a === 1 => 'one',
             match_statement_test_is_two($a) => 'two',
             MatchStatementClass::isThree($a) => 'three',
-            (new MatchStatementClass)->isFour($a) => 'four',
+            (new MatchStatementClass)->isFour(a: $a) => 'four',
             $a instanceof MatchStatementClass => 'five',
             $a instanceof DateTime => 'six',
             default => 'other',

--- a/tests/SerializerTest.php
+++ b/tests/SerializerTest.php
@@ -510,13 +510,13 @@ class SerializerPhp74Class
 
 test('instanceof', function () {
     $closure = function ($a) {
-        $b = $a instanceof DateTime || $a instanceof SerializerPhp74Class || $a instanceof RegularClass;
+        $b = $a instanceof DateTime || $a instanceof SerializerPhp74Class || $a instanceof Model;
 
         return [
             $b,
-            $a instanceof DateTime || $a instanceof SerializerPhp74Class || $a instanceof RegularClass,
+            $a instanceof DateTime || $a instanceof SerializerPhp74Class || $a instanceof Model,
             (function ($a) {
-                return ($a instanceof DateTime || $a instanceof SerializerPhp74Class || $a instanceof RegularClass) === true;
+                return ($a instanceof DateTime || $a instanceof SerializerPhp74Class || $a instanceof Model) === true;
             })($a),
         ];
     };
@@ -525,7 +525,7 @@ test('instanceof', function () {
 
     expect($u(new DateTime))->toEqual([true, true, true])
         ->and($u(new SerializerPhp74Class))->toEqual([true, true, true])
-        ->and($u(new RegularClass))->toEqual([true, true, true])
+        ->and($u(new Model))->toEqual([true, true, true])
         ->and($u(new stdClass))->toEqual([false, false, false]);
 })->with('serializers');
 
@@ -544,7 +544,7 @@ test('switch statement', function () {
                 return 'five';
             case $a instanceof DateTime:
                 return 'six';
-            case $a instanceof RegularClass:
+            case $a instanceof Model:
                 return 'seven';
             default:
                 return 'other';
@@ -559,7 +559,7 @@ test('switch statement', function () {
         ->and($u(4))->toEqual('four')
         ->and($u(new SerializerPhp74SwitchStatementClass))->toEqual('five')
         ->and($u(new DateTime))->toEqual('six')
-        ->and($u(new RegularClass()))->toEqual('seven')
+        ->and($u(new Model()))->toEqual('seven')
         ->and($u(999))->toEqual('other');
 })->with('serializers');
 

--- a/tests/SerializerTest.php
+++ b/tests/SerializerTest.php
@@ -485,6 +485,56 @@ test('serializes with used object date properties', function ($_, $date) {
     new CarbonImmutable,
 ]);
 
+function switch_statement_test_is_two($a)
+{
+    return $a === 2;
+};
+
+class SwitchStatementClass
+{
+    public static function isThree($a)
+    {
+        return $a === 3;
+    }
+
+    public function isFour($a)
+    {
+        return $a === 4;
+    }
+}
+
+test('switch statement', function () {
+    $closure = function ($a) {
+        switch (true) {
+            // all possible cases, and returns...
+            case $a === 1:
+                return 'one';
+            case switch_statement_test_is_two($a):
+                return 'two';
+            case SwitchStatementClass::isThree($a):
+                return 'three';
+            case (new SwitchStatementClass)->isFour($a):
+                return 'four';
+            case $a instanceof SwitchStatementClass:
+                return 'five';
+            case $a instanceof DateTime:
+                return 'six';
+            default:
+                return 'other';
+        }
+    };
+
+    $u = s($closure);
+
+    expect($u(1))->toEqual('one')
+        ->and($u(2))->toEqual('two')
+        ->and($u(3))->toEqual('three')
+        ->and($u(4))->toEqual('four')
+        ->and($u(new SwitchStatementClass))->toEqual('five')
+        ->and($u(new DateTime))->toEqual('six')
+        ->and($u(999))->toEqual('other');
+})->with('serializers');
+
 class A
 {
     protected static function aStaticProtected()
@@ -567,3 +617,4 @@ class ObjWithConst
 {
     const FOO = 'bar';
 }
+

--- a/tests/SerializerTest.php
+++ b/tests/SerializerTest.php
@@ -7,6 +7,7 @@ use Laravel\SerializableClosure\Serializers\Signed;
 use Laravel\SerializableClosure\Support\ReflectionClosure;
 use Laravel\SerializableClosure\UnsignedSerializableClosure;
 use Tests\Fixtures\Model;
+use Tests\Fixtures\RegularClass;
 
 test('closure with simple const', function () {
     $c = function () {
@@ -509,13 +510,13 @@ class SerializerPhp74Class
 
 test('instanceof', function () {
     $closure = function ($a) {
-        $b = $a instanceof DateTime || $a instanceof SerializerPhp74Class;
+        $b = $a instanceof DateTime || $a instanceof SerializerPhp74Class || $a instanceof RegularClass;
 
         return [
             $b,
-            $a instanceof DateTime || $a instanceof SerializerPhp74Class,
+            $a instanceof DateTime || $a instanceof SerializerPhp74Class || $a instanceof RegularClass,
             (function ($a) {
-                return ($a instanceof DateTime || $a instanceof SerializerPhp74Class) === true;
+                return ($a instanceof DateTime || $a instanceof SerializerPhp74Class || $a instanceof RegularClass) === true;
             })($a),
         ];
     };
@@ -524,6 +525,7 @@ test('instanceof', function () {
 
     expect($u(new DateTime))->toEqual([true, true, true])
         ->and($u(new SerializerPhp74Class))->toEqual([true, true, true])
+        ->and($u(new RegularClass))->toEqual([true, true, true])
         ->and($u(new stdClass))->toEqual([false, false, false]);
 })->with('serializers');
 
@@ -542,6 +544,8 @@ test('switch statement', function () {
                 return 'five';
             case $a instanceof DateTime:
                 return 'six';
+            case $a instanceof RegularClass:
+                return 'seven';
             default:
                 return 'other';
         }
@@ -555,6 +559,7 @@ test('switch statement', function () {
         ->and($u(4))->toEqual('four')
         ->and($u(new SerializerPhp74SwitchStatementClass))->toEqual('five')
         ->and($u(new DateTime))->toEqual('six')
+        ->and($u(new RegularClass()))->toEqual('seven')
         ->and($u(999))->toEqual('other');
 })->with('serializers');
 

--- a/tests/SerializerTest.php
+++ b/tests/SerializerTest.php
@@ -513,9 +513,9 @@ test('instanceof', function () {
 
         return [
             $b,
-            $a instanceof DateTime || $a instanceof InstanceOfTestClass,
+            $a instanceof DateTime || $a instanceof SerializerPhp74Class,
             (function ($a) {
-                return ($a instanceof DateTime || $a instanceof InstanceOfTestClass) === true;
+                return ($a instanceof DateTime || $a instanceof SerializerPhp74Class) === true;
             })($a),
         ];
     };

--- a/tests/SerializerTest.php
+++ b/tests/SerializerTest.php
@@ -488,7 +488,7 @@ test('serializes with used object date properties', function ($_, $date) {
 function switch_statement_test_is_two($a)
 {
     return $a === 2;
-};
+}
 
 class SwitchStatementClass
 {
@@ -617,4 +617,3 @@ class ObjWithConst
 {
     const FOO = 'bar';
 }
-

--- a/tests/SerializerTest.php
+++ b/tests/SerializerTest.php
@@ -485,12 +485,12 @@ test('serializes with used object date properties', function ($_, $date) {
     new CarbonImmutable,
 ]);
 
-function switch_statement_test_is_two($a)
+function serializer_php_74_switch_statement_test_is_two($a)
 {
     return $a === 2;
 }
 
-class SwitchStatementClass
+class SerializerPhp74SwitchStatementClass
 {
     public static function isThree($a)
     {
@@ -503,24 +503,23 @@ class SwitchStatementClass
     }
 }
 
-class InstanceOfTestClass {};
+class SerializerPhp74Class {};
 
 test('instanceof', function () {
     $closure = function ($a) {
-        $b = $a instanceof DateTime || $a instanceof InstanceOfTestClass;
+        $b = $a instanceof DateTime || $a instanceof SerializerPhp74Class;
 
         return [
             $b,
-            ($a instanceof DateTime || $a instanceof InstanceOfTestClass),
-            (function ($a) { return ($a instanceof DateTime || $a instanceof InstanceOfTestClass) === true; })($a),
+            ($a instanceof DateTime || $a instanceof SerializerPhp74Class),
+            (function ($a) { return ($a instanceof DateTime || $a instanceof SerializerPhp74Class) === true; })($a),
         ];
-
     };
 
     $u = s($closure);
 
     expect($u(new DateTime))->toEqual([true, true, true])
-        ->and($u(new InstanceOfTestClass))->toEqual([true, true, true])
+        ->and($u(new SerializerPhp74Class))->toEqual([true, true, true])
         ->and($u(new stdClass))->toEqual([false, false, false]);
 })->with('serializers');
 
@@ -529,13 +528,13 @@ test('switch statement', function () {
         switch (true) {
             case $a === 1:
                 return 'one';
-            case switch_statement_test_is_two($a):
+            case serializer_php_74_switch_statement_test_is_two($a):
                 return 'two';
-            case SwitchStatementClass::isThree($a):
+            case SerializerPhp74SwitchStatementClass::isThree($a):
                 return 'three';
-            case (new SwitchStatementClass)->isFour($a):
+            case (new SerializerPhp74SwitchStatementClass)->isFour($a):
                 return 'four';
-            case $a instanceof SwitchStatementClass:
+            case $a instanceof SerializerPhp74SwitchStatementClass:
                 return 'five';
             case $a instanceof DateTime:
                 return 'six';
@@ -550,7 +549,7 @@ test('switch statement', function () {
         ->and($u(2))->toEqual('two')
         ->and($u(3))->toEqual('three')
         ->and($u(4))->toEqual('four')
-        ->and($u(new SwitchStatementClass))->toEqual('five')
+        ->and($u(new SerializerPhp74SwitchStatementClass))->toEqual('five')
         ->and($u(new DateTime))->toEqual('six')
         ->and($u(999))->toEqual('other');
 })->with('serializers');

--- a/tests/SerializerTest.php
+++ b/tests/SerializerTest.php
@@ -503,10 +503,30 @@ class SwitchStatementClass
     }
 }
 
+class InstanceOfTestClass {};
+
+test('instanceof', function () {
+    $closure = function ($a) {
+        $b = $a instanceof DateTime || $a instanceof InstanceOfTestClass;
+
+        return [
+            $b,
+            ($a instanceof DateTime || $a instanceof InstanceOfTestClass),
+            (function ($a) { return ($a instanceof DateTime || $a instanceof InstanceOfTestClass) === true; })($a),
+        ];
+
+    };
+
+    $u = s($closure);
+
+    expect($u(new DateTime))->toEqual([true, true, true])
+        ->and($u(new InstanceOfTestClass))->toEqual([true, true, true])
+        ->and($u(new stdClass))->toEqual([false, false, false]);
+})->with('serializers');
+
 test('switch statement', function () {
     $closure = function ($a) {
         switch (true) {
-            // all possible cases, and returns...
             case $a === 1:
                 return 'one';
             case switch_statement_test_is_two($a):


### PR DESCRIPTION
This pull request fixes https://github.com/laravel/serializable-closure/issues/78, witch is related to the usage of switch cases cases combined with namespace resolution.

So, prior to this pull request, the following scenario was not possible:

```php
use Laravel\Scout\Searchable;

Route::get('show', function (User|Product $model) {
    switch(true) {
        $user instanceof Searchable: // bug here, because Searchable was not converted to $user instanceof \Laravel\Scout\Searchable;
            return view('search-view');
    return view('regular');
});
```