### PR TITLE
Fix bug related to readonly properties

### DIFF
--- a/src/Serializers/Native.php
+++ b/src/Serializers/Native.php
@@ -368,7 +368,7 @@ class Native implements Serializable
                 }
 
                 foreach ($reflection->getProperties() as $property) {
-                    if ($property->isStatic() || ! $property->getDeclaringClass()->isUserDefined()) {
+                    if ($property->isStatic() || ! $property->getDeclaringClass()->isUserDefined() || $property->isReadOnly()) {
                         continue;
                     }
 

--- a/src/Serializers/Native.php
+++ b/src/Serializers/Native.php
@@ -368,13 +368,17 @@ class Native implements Serializable
                 }
 
                 foreach ($reflection->getProperties() as $property) {
-                    if ($property->isStatic() || ! $property->getDeclaringClass()->isUserDefined() || $property->isReadOnly()) {
+                    if ($property->isStatic() || ! $property->getDeclaringClass()->isUserDefined()) {
                         continue;
                     }
 
                     $property->setAccessible(true);
 
                     if (PHP_VERSION >= 7.4 && ! $property->isInitialized($data)) {
+                        continue;
+                    }
+
+                    if (PHP_VERSION >= 8.1 && $property->isReadOnly()) {
                         continue;
                     }
 

--- a/tests/SerializerPhp81Test.php
+++ b/tests/SerializerPhp81Test.php
@@ -169,6 +169,20 @@ test('readonly properties', function () {
     });
 })->with('serializers');
 
+test('readonly properties from parent scope variable', function () {
+    $controller = new SerializerPhp81Controller();
+
+    $f = static function () use ($controller) {
+        return $controller;
+    };
+
+    $f = s($f);
+
+    expect($f()->service)->toBeInstanceOf(
+        SerializerPhp81Service::class,
+    );
+})->with('serializers');
+
 test('first-class callable with closures', function () {
     $f = function ($value) {
         return $value;


### PR DESCRIPTION
This pull request fix [this issue](https://github.com/laravel/framework/issues/51877) where an exception is thrown during the unserialize process when `Bus::chain` handles a class that includes a readonly property. The exception message is: `Cannot modify readonly property Illuminate\Tests\Integration\Queue\ReadonlyEnumTestJob::$enum`.