### PR TITLE
Fix for readonly properties that declared in parent

### DIFF
--- a/src/Serializers/Native.php
+++ b/src/Serializers/Native.php
@@ -504,6 +504,10 @@ class Native implements Serializable
                         continue;
                     }
 
+                    if (PHP_VERSION >= 8.1 && $property->isReadOnly() && $property->class !== $reflection->name) {
+                        continue;
+                    }
+
                     $value = $property->getValue($instance);
 
                     if (is_array($value) || is_object($value)) {

--- a/tests/SerializerPhp81Test.php
+++ b/tests/SerializerPhp81Test.php
@@ -183,6 +183,20 @@ test('readonly properties from parent scope variable', function () {
     );
 })->with('serializers');
 
+test('readonly properties declared in parent', function () {
+    $controller = new SerializerPhp81ControllerChild();
+
+    $f = static function () use ($controller) {
+        return $controller;
+    };
+
+    $f = s($f);
+
+    expect($f()->service)->toBeInstanceOf(
+        SerializerPhp81Service::class,
+    );
+})->with('serializers');
+
 test('first-class callable with closures', function () {
     $f = function ($value) {
         return $value;
@@ -588,6 +602,8 @@ class SerializerPhp81Service implements SerializerPhp81HasId, SerializerPhp81Has
 {
     final public const X = 'foo';
 }
+
+class SerializerPhp81ControllerChild extends SerializerPhp81Controller {}
 
 class SerializerPhp81Controller
 {

--- a/tests/SerializerPhp81Test.php
+++ b/tests/SerializerPhp81Test.php
@@ -184,17 +184,25 @@ test('readonly properties from parent scope variable', function () {
 })->with('serializers');
 
 test('readonly properties declared in parent', function () {
-    $controller = new SerializerPhp81ControllerChild();
+    $childWithDefaultValue = new SerializerPhp81Child();
 
-    $f = static function () use ($controller) {
-        return $controller;
+    $f = static function () use ($childWithDefaultValue) {
+        return $childWithDefaultValue;
     };
 
     $f = s($f);
 
-    expect($f()->service)->toBeInstanceOf(
-        SerializerPhp81Service::class,
-    );
+    expect($f()->property)->toBe(1);
+
+    $child = new SerializerPhp81Child(100);
+
+    $f = static function () use ($child) {
+        return $child;
+    };
+
+    $f = s($f);
+
+    expect($f()->property)->toBe(100);
 })->with('serializers');
 
 test('first-class callable with closures', function () {
@@ -598,12 +606,19 @@ test('function attributes with first-class callable with methods', function () {
 interface SerializerPhp81HasId {}
 interface SerializerPhp81HasName {}
 
+class SerializerPhp81Child extends SerializerPhp81Parent {}
+
+class SerializerPhp81Parent
+{
+    public function __construct(
+        public readonly int $property = 1,
+    ) {}
+}
+
 class SerializerPhp81Service implements SerializerPhp81HasId, SerializerPhp81HasName
 {
     final public const X = 'foo';
 }
-
-class SerializerPhp81ControllerChild extends SerializerPhp81Controller {}
 
 class SerializerPhp81Controller
 {


### PR DESCRIPTION
If you try to serialize an object that has readonly properties that declared in parent, you will get an error "Cannot initialize readonly property Parent::$property from scope Child". This PR fixes this
```php
class Parent
{
    public function __construct(
        public readonly int $property = 1,
    ) {}
}

class Child extends Parent {}

$object = new Child();

$closure = static fn () => $object;

serialize(new \Laravel\SerializableClosure\SerializableClosure($closure));
```