### PR TITLE
[2.x] Fix namespaced closures being considered first class callables

### DIFF
--- a/src/Support/ReflectionClosure.php
+++ b/src/Support/ReflectionClosure.php
@@ -1169,8 +1169,14 @@ class ReflectionClosure extends ReflectionFunction
     {
         $ns = $this->getNamespaceName();
 
+        $name = $this->getName();
+
         // First class callables...
-        if ($this->getName() !== '{closure}' && empty($ns) && ! is_null($this->getClosureScopeClass())) {
+        if ($name !== '{closure}'
+            && ! str_contains($name, '{closure:/')
+            && ! str_contains($name, '{closure:\\')
+            && empty($ns)
+            && ! is_null($this->getClosureScopeClass())) {
             $ns = $this->getClosureScopeClass()->getNamespaceName();
         }
 


### PR DESCRIPTION
This pull request fixes PHP 8.4 support in this package; the issue was: closures without any namespace were being considered first class callables (aka `class::method(...)`).