### PR TITLE
Fix broken code for ternary operator with class instantiation with omitted parentheses

### DIFF
--- a/src/Support/ReflectionClosure.php
+++ b/src/Support/ReflectionClosure.php
@@ -508,7 +508,7 @@ class ReflectionClosure extends ReflectionFunction
                     break;
                 case 'id_name':
                     switch ($token[0]) {
-                        case $token[0] === ':' && !in_array($context, ['instanceof', 'new']):
+                        case $token[0] === ':' && !in_array($context, ['instanceof', 'new'], true):
                             if ($lastState === 'closure' && $context === 'root') {
                                 $state = 'closure';
                                 $code .= $id_start.$token;

--- a/src/Support/ReflectionClosure.php
+++ b/src/Support/ReflectionClosure.php
@@ -508,7 +508,7 @@ class ReflectionClosure extends ReflectionFunction
                     break;
                 case 'id_name':
                     switch ($token[0]) {
-                        case $token[0] === ':' && $context !== 'instanceof':
+                        case $token[0] === ':' && !in_array($context, ['instanceof', 'new']):
                             if ($lastState === 'closure' && $context === 'root') {
                                 $state = 'closure';
                                 $code .= $id_start.$token;

--- a/src/Support/ReflectionClosure.php
+++ b/src/Support/ReflectionClosure.php
@@ -508,7 +508,7 @@ class ReflectionClosure extends ReflectionFunction
                     break;
                 case 'id_name':
                     switch ($token[0]) {
-                        case $token[0] === ':' && !in_array($context, ['instanceof', 'new'], true):
+                        case $token[0] === ':' && ! in_array($context, ['instanceof', 'new'], true):
                             if ($lastState === 'closure' && $context === 'root') {
                                 $state = 'closure';
                                 $code .= $id_start.$token;

--- a/tests/ReflectionClosure5Test.php
+++ b/tests/ReflectionClosure5Test.php
@@ -5,6 +5,7 @@ use Foo\Baz\Qux;
 use Foo\Baz\Qux\Forest;
 use Laravel\SerializableClosure\Support\ReflectionClosure;
 use Tests\Fixtures\Model;
+use Tests\Fixtures\RegularClass;
 
 test('is short closure', function () {
     $f1 = fn () => 1;
@@ -238,6 +239,21 @@ test('from static callable namespaces', function () {
     $e = 'static function (\Tests\Fixtures\Model $model): \Tests\Fixtures\Model
     {
         return new \Tests\Fixtures\Model();
+    }';
+
+    expect($f)->toBeCode($e);
+});
+
+test('ternanry operator new without constructor', function () {
+    $f = function () {
+        $flag = true;
+
+        return $flag ? new RegularClass : new RegularClass;
+    };
+    $e = 'function () {
+        $flag = true;
+
+        return $flag ? new \Tests\Fixtures\RegularClass : new \Tests\Fixtures\RegularClass;
     }';
 
     expect($f)->toBeCode($e);


### PR DESCRIPTION
Hello there!
I have encountered broken code generation with the new operator inside ternary operator.
ReflectionClosure->getCode() skips the ':' symbol if constructor parentheses are omitted.
Sample code:
```php
function () {
    $flag = true;
    return $flag ? new RegularClass : new RegularClass;
}
```
will result a broken code:
```php
function () {
     $flag = true;
     return $flag ? new \Tests\Fixtures\RegularClass  new \Tests\Fixtures\RegularClass;
}
``` 
This can be reproduced in 1.x branch as well.

