### PR TITLE
Result in syntax error when serializing `instanceof {expression}`

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,8 +1,0 @@
-# Default ignored files
-/shelf/
-/workspace.xml
-# Editor-based HTTP Client requests
-/httpRequests/
-# Datasource local storage ignored files
-/dataSources/
-/dataSources.local.xml

--- a/tests/ReflectionClosure6Test.php
+++ b/tests/ReflectionClosure6Test.php
@@ -8,8 +8,12 @@ use Tests\Fixtures\Model;
 use Tests\Fixtures\RegularClass;
 
 test('resolve instanceof with class_exists()', function () {
-	$f1 = fn (Baz $a) => $this instanceof (class_exists(Foo::class) ? Foo::class : Forest::class);
-	$e1 = 'fn (\Foo\Bar $a) => $this instanceof (class_exists(\Foo:class) ? \Foo::class : \Foo\Baz\Qux\Forest::class)';
+	$f1 = fn (Baz $a) => $this instanceof (Forest::class); // Turning `instanceof` into an expression results into this incorrect compilation
+	$e1 = 'fn (\Foo\Bar $a) => $this instanceof (\Foo\Baz\Qux\Forest::class)';
+	
+	$f2 = fn (Baz $a) => $this instanceof (class_exists(Foo::class) ? Foo::class : Forest::class);
+	$e2 = 'fn (\Foo\Bar $a) => $this instanceof (class_exists(\Foo:class) ? \Foo::class : \Foo\Baz\Qux\Forest::class)';
 	
     expect($f1)->toBeCode($e1);
+    expect($f2)->toBeCode($e2);
 });

--- a/tests/ReflectionClosure6Test.php
+++ b/tests/ReflectionClosure6Test.php
@@ -1,0 +1,15 @@
+<?php
+
+use Foo\Bar as Baz;
+use Foo\Baz\Qux;
+use Foo\Baz\Qux\Forest;
+use Laravel\SerializableClosure\Support\ReflectionClosure;
+use Tests\Fixtures\Model;
+use Tests\Fixtures\RegularClass;
+
+test('resolve instanceof with class_exists()', function () {
+	$f1 = fn (Baz $a) => $this instanceof (class_exists(Foo::class) ? Foo::class : Forest::class);
+	$e1 = 'fn (\Foo\Bar $a) => $this instanceof (class_exists(\Foo:class) ? \Foo::class : \Foo\Baz\Qux\Forest::class)';
+	
+    expect($f1)->toBeCode($e1);
+});

--- a/tests/ReflectionClosure6Test.php
+++ b/tests/ReflectionClosure6Test.php
@@ -7,7 +7,7 @@ use Laravel\SerializableClosure\Support\ReflectionClosure;
 use Tests\Fixtures\Model;
 use Tests\Fixtures\RegularClass;
 
-test('resolve instanceof with class_exists()', function () {
+test('resolve instanceof with expression', function () {
 	$f1 = fn (Baz $a) => $this instanceof (Forest::class); // Turning `instanceof` into an expression results into this incorrect compilation
 	$e1 = 'fn (\Foo\Bar $a) => $this instanceof (\Foo\Baz\Qux\Forest::class)';
 	


### PR DESCRIPTION
Hello, I noticed that when serializing any `instanceof` with the result being an expression fails.

For example, code that fails is:
```php
$this instanceof (Foo::class)
```
Practical example:
```php
if ($this instanceof (class_exists(Foo::class) ? Foo::class : Bar::class)) {}
```

This type of code gets compiled into:
```
fn (\Foo\Bar $a) => $this instanceof \Foo\Bar (\Foo\Baz\Qux\Forest::class)
```

Basically, it seems like the serializable closure takes the last class that it replaced/imported the full namespace for, and puts it after the `instanceof` and before the expression, thus resulting in this syntax error: `$this instanceof \Foo\Bar (...)`.

I first added a failing test to identify it. Then I looked into if I could pinpoint the issue, but unfortunately I did not find it myself. If someone with good knowledge of this could pinpoint me to the correct place where to make the fix would be awesome. Also, feel free to take over the PR.

Thanks!