### PR TITLE
Fix namespaces for PHP 8.4

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -4,6 +4,8 @@ php:
   finder:
     not-name:
       - Php84Test.php
+      - ReflectionClosureBracedNamespaceTest.php
+      - ReflectionClosureNonBracedNamespaceTest.php
       - ReflectionClosurePhp80Test.php
       - ReflectionClosurePhp81Test.php
       - SerializerPhp81Test.php

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -16,6 +16,8 @@
             <file>tests/ReflectionClosure3Test.php</file>
             <file>tests/ReflectionClosure4Test.php</file>
             <file>tests/ReflectionClosure5Test.php</file>
+            <file>tests/ReflectionClosureBracedNamespaceTest.php</file>
+            <file>tests/ReflectionClosureNonBracedNamespaceTest.php</file>
             <file>tests/SerializerTest.php</file>
             <file>tests/SignedSerializerTest.php</file>
         </testsuite>

--- a/src/Support/ReflectionClosure.php
+++ b/src/Support/ReflectionClosure.php
@@ -945,14 +945,33 @@ class ReflectionClosure extends ReflectionFunction
         $alias = '';
         $isFunc = $isConst = false;
 
-        $startLine = $endLine = 0;
+        $startLine = $lastKnownLine = 0;
         $structType = $structName = '';
         $structIgnore = false;
 
+        $namespace = '';
+        $namespaceStartLine = 0;
+        $namespaceBraced = false;
+
         foreach ($tokens as $token) {
+            if (is_array($token)) {
+                $lastKnownLine = $token[2];
+            }
+
             switch ($state) {
                 case 'start':
                     switch ($token[0]) {
+                        case T_NAMESPACE:
+                            $structures[] = [
+                                'type' => 'namespace',
+                                'name' => $namespace,
+                                'start' => $namespaceStartLine,
+                                'end' => $token[2] - 1,
+                            ];
+                            $namespace = '';
+                            $state = 'namespace';
+                            $namespaceStartLine = $token[2];
+                            break;
                         case T_CLASS:
                         case T_INTERFACE:
                         case T_TRAIT:
@@ -977,6 +996,31 @@ class ReflectionClosure extends ReflectionFunction
                         case T_OBJECT_OPERATOR:
                         case T_DOUBLE_COLON:
                             $state = 'invoke';
+                            break;
+                        case '}':
+                            if ($namespaceBraced) {
+                                $structures[] = [
+                                    'type' => 'namespace',
+                                    'name' => $namespace,
+                                    'start' => $namespaceStartLine,
+                                    'end' => $lastKnownLine,
+                                ];
+                                $namespaceBraced = false;
+                                $namespace = '';
+                            }
+                            break;
+                    }
+                    break;
+                case 'namespace':
+                    switch ($token[0]) {
+                        case T_STRING:
+                        case T_NAME_QUALIFIED:
+                            $namespace = $token[1];
+                            break;
+                        case ';':
+                        case '{':
+                            $state = 'start';
+                            $namespaceBraced = $token[0] === '{';
                             break;
                     }
                     break;
@@ -1118,21 +1162,24 @@ class ReflectionClosure extends ReflectionFunction
                                         'type' => $structType,
                                         'name' => $structName,
                                         'start' => $startLine,
-                                        'end' => $endLine,
+                                        'end' => $lastKnownLine,
                                     ];
                                 }
                                 $structIgnore = false;
                                 $state = 'start';
                             }
                             break;
-                        default:
-                            if (is_array($token)) {
-                                $endLine = $token[2];
-                            }
                     }
                     break;
             }
         }
+
+        $structures[] = [
+            'type' => 'namespace',
+            'name' => $namespace,
+            'start' => $namespaceStartLine,
+            'end' => PHP_INT_MAX,
+        ];
 
         static::$classes[$key] = $classes;
         static::$functions[$key] = $functions;
@@ -1147,20 +1194,19 @@ class ReflectionClosure extends ReflectionFunction
      */
     protected function getClosureNamespaceName()
     {
-        $ns = $this->getNamespaceName();
+        $startLine = $this->getStartLine();
+        $endLine = $this->getEndLine();
 
-        $name = $this->getName();
-
-        // First class callables...
-        if ($name !== '{closure}'
-            && ! str_contains($name, '{closure:/')
-            && ! str_contains($name, '{closure:\\')
-            && empty($ns)
-            && ! is_null($this->getClosureScopeClass())) {
-            $ns = $this->getClosureScopeClass()->getNamespaceName();
+        foreach ($this->getStructures() as $struct) {
+            if ($struct['type'] === 'namespace' &&
+                $struct['start'] <= $startLine &&
+                $struct['end'] >= $endLine
+            ) {
+                return $struct['name'];
+            }
         }
 
-        return $ns;
+        return '';
     }
 
     /**

--- a/src/Support/ReflectionClosure.php
+++ b/src/Support/ReflectionClosure.php
@@ -865,13 +865,18 @@ class ReflectionClosure extends ReflectionFunction
      */
     protected function getClasses()
     {
-        $key = $this->getHashedFileName();
+        $line = $this->getStartLine();
 
-        if (! isset(static::$classes[$key])) {
-            $this->fetchItems();
+        foreach ($this->getStructures() as $struct) {
+            if ($struct['type'] === 'namespace' &&
+                $struct['start'] <= $line &&
+                $struct['end'] >= $line
+            ) {
+                return $struct['classes'];
+            }
         }
 
-        return static::$classes[$key];
+        return [];
     }
 
     /**
@@ -952,6 +957,7 @@ class ReflectionClosure extends ReflectionFunction
         $namespace = '';
         $namespaceStartLine = 0;
         $namespaceBraced = false;
+        $namespaceClasses = [];
 
         foreach ($tokens as $token) {
             if (is_array($token)) {
@@ -967,8 +973,10 @@ class ReflectionClosure extends ReflectionFunction
                                 'name' => $namespace,
                                 'start' => $namespaceStartLine,
                                 'end' => $token[2] - 1,
+                                'classes' => $namespaceClasses,
                             ];
                             $namespace = '';
+                            $namespaceClasses = [];
                             $state = 'namespace';
                             $namespaceStartLine = $token[2];
                             break;
@@ -1004,9 +1012,11 @@ class ReflectionClosure extends ReflectionFunction
                                     'name' => $namespace,
                                     'start' => $namespaceStartLine,
                                     'end' => $lastKnownLine,
+                                    'classes' => $namespaceClasses,
                                 ];
                                 $namespaceBraced = false;
                                 $namespace = '';
+                                $namespaceClasses = [];
                             }
                             break;
                     }
@@ -1066,6 +1076,7 @@ class ReflectionClosure extends ReflectionFunction
                                     $constants[$alias] = $name;
                                 } else {
                                     $classes[strtolower($alias)] = $name;
+                                    $namespaceClasses[strtolower($alias)] = $name;
                                 }
                             }
                             $name = $alias = '';
@@ -1105,6 +1116,7 @@ class ReflectionClosure extends ReflectionFunction
                                     $constants[$alias] = $prefix.$name;
                                 } else {
                                     $classes[strtolower($alias)] = $prefix.$name;
+                                    $namespaceClasses[strtolower($alias)] = $prefix.$name;
                                 }
                             }
                             $name = $alias = '';
@@ -1179,6 +1191,7 @@ class ReflectionClosure extends ReflectionFunction
             'name' => $namespace,
             'start' => $namespaceStartLine,
             'end' => PHP_INT_MAX,
+            'classes' => $namespaceClasses,
         ];
 
         static::$classes[$key] = $classes;

--- a/tests/ReflectionClosureBracedNamespaceTest.php
+++ b/tests/ReflectionClosureBracedNamespaceTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Space {
+    test('relative namespace (braced)', function () {
+        $f1 = fn (Foo $foo): Foo => new Foo();
+        $e1 = 'fn (\Space\Foo $foo): \Space\Foo => new \Space\Foo()';
+
+        $f2 = fn (Foo\Bar $fooBar): Foo\Bar => new Foo\Bar();
+        $e2 = 'fn (\Space\Foo\Bar $fooBar): \Space\Foo\Bar => new \Space\Foo\Bar()';
+
+        expect($f1)->toBeCode($e1);
+        expect($f2)->toBeCode($e2);
+    });
+}
+
+namespace Irrelevant {}
+
+namespace Sub\Space {
+    test('relative other namespace (braced)', function () {
+        $f1 = fn (Foo $foo): Foo => new Foo();
+        $e1 = 'fn (\Sub\Space\Foo $foo): \Sub\Space\Foo => new \Sub\Space\Foo()';
+
+        expect($f1)->toBeCode($e1);
+    });
+}
+
+namespace {
+    test('back to global namespace (braced)', function () {
+        $f1 = fn (Foo $foo): Foo => new Foo();
+        $e1 = 'fn (\Foo $foo): \Foo => new \Foo()';
+        expect($f1)->toBeCode($e1);
+    });
+}

--- a/tests/ReflectionClosureBracedNamespaceTest.php
+++ b/tests/ReflectionClosureBracedNamespaceTest.php
@@ -31,3 +31,20 @@ namespace {
         expect($f1)->toBeCode($e1);
     });
 }
+
+namespace Irrelevant {
+    // Shouldn't be used below, as not in the same namespace
+    use Wrong as Qux;
+}
+
+namespace Space {
+    test('no using use from other namespace', function () {
+        $f1 = fn (Qux $qux) => true;
+        $e1 = 'fn (\Space\Qux $qux) => true';
+
+        expect($f1)->toBeCode($e1);
+    });
+
+    // Shouldn't be used above, as declared after usage.  Not currently supported though.
+    // use AlsoWrong as Qux;
+}

--- a/tests/ReflectionClosureNonBracedNamespaceTest.php
+++ b/tests/ReflectionClosureNonBracedNamespaceTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Space;
+
+test('relative namespace (non-braced)', function () {
+    $f1 = fn (Foo $foo): Foo => new Foo();
+    $e1 = 'fn (\Space\Foo $foo): \Space\Foo => new \Space\Foo()';
+
+    $f2 = fn (Foo\Bar $fooBar): Foo\Bar => new Foo\Bar();
+    $e2 = 'fn (\Space\Foo\Bar $fooBar): \Space\Foo\Bar => new \Space\Foo\Bar()';
+
+    expect($f1)->toBeCode($e1);
+    expect($f2)->toBeCode($e2);
+});
+
+namespace Irrelevant;
+namespace Sub\Space;
+
+test('relative other namespace (non-braced)', function () {
+    $f1 = fn (Foo $foo): Foo => new Foo();
+    $e1 = 'fn (\Sub\Space\Foo $foo): \Sub\Space\Foo => new \Sub\Space\Foo()';
+
+    expect($f1)->toBeCode($e1);
+});

--- a/tests/ReflectionClosureNonBracedNamespaceTest.php
+++ b/tests/ReflectionClosureNonBracedNamespaceTest.php
@@ -22,3 +22,20 @@ test('relative other namespace (non-braced)', function () {
 
     expect($f1)->toBeCode($e1);
 });
+
+namespace Irrelevant;
+
+// Shouldn't be used below, as not in the same namespace
+use Wrong as Qux;
+
+namespace Space;
+
+test('not using use from other namespace', function () {
+    $f1 = fn (Qux $qux) => true;
+    $e1 = 'fn (\Space\Qux $qux) => true';
+
+    expect($f1)->toBeCode($e1);
+});
+
+// Shouldn't be used above, as declared after usage.  Not currently supported though.
+// use AlsoWrong as Qux;


### PR DESCRIPTION
Fixes relative namespaces handling for PHP 8.4, which has an unfortunate breaking change about how `ReflectionFunction::getNamespaceName()` works for closures.

It also fixes namespace resolution in files with multiple namespaces, where only the `use` statements in the current namespace must be considered.

Fixes #111