### PR TITLE
support function attributes with array arguments

### DIFF
--- a/src/Support/ReflectionClosure.php
+++ b/src/Support/ReflectionClosure.php
@@ -685,7 +685,7 @@ class ReflectionClosure extends ReflectionFunction
 
             $name = $attribute->getName();
             $arguments = implode(', ', array_map(function ($argument, $key) {
-                $argument = sprintf("'%s'", str_replace("'", "\\'", $argument));
+                $argument = var_export($argument, true);
 
                 if (is_string($key)) {
                     $argument = sprintf('%s: %s', $key, $argument);

--- a/tests/ReflectionClosurePhp81Test.php
+++ b/tests/ReflectionClosurePhp81Test.php
@@ -589,8 +589,8 @@ test('function attributes with arguments', function () {
         return true;
     };
 
-    $e = <<<EOF
-#[MyAttribute('My " \' Argument 1', 'Tests\Fixtures\Model')]
+    $e = <<<'EOF'
+#[MyAttribute('My " \' Argument 1', 'Tests\\Fixtures\\Model')]
 function () {
         return true;
     }
@@ -606,8 +606,8 @@ test('function attributes with named arguments', function () {
         return false;
     };
 
-    $e = <<<EOF
-#[MyAttribute(string: 'My " \' Argument 1', model: 'Tests\Fixtures\Model')]
+    $e = <<<'EOF'
+#[MyAttribute(string: 'My " \' Argument 1', model: 'Tests\\Fixtures\\Model')]
 function () {
         return false;
     }
@@ -621,12 +621,32 @@ test('function attributes with first-class callable with methods', function () {
 
     $f = (new SerializerPhp81Controller())->publicGetter(...);
 
-    $e = <<<EOF
+    $e = <<<'EOF'
 #[Tests\Fixtures\ModelAttribute()]
-#[MyAttribute('My " \' Argument 1', 'Tests\Fixtures\Model')]
+#[MyAttribute('My " \' Argument 1', 'Tests\\Fixtures\\Model')]
 function ()
     {
-        return \$this->privateGetter();
+        return $this->privateGetter();
+    }
+EOF;
+
+    expect($f)->toBeCode($e);
+});
+
+test('function attributes with array arguments', function () {
+    $model = new Model();
+
+    $f = #[MyAttribute('My Argument', ['one', 'two'])] function (): bool {
+        return true;
+    };
+
+    $e = <<<'EOF'
+#[MyAttribute('My Argument', array (
+  0 => 'one',
+  1 => 'two',
+))]
+function (): bool {
+        return true;
     }
 EOF;
 

--- a/tests/SerializerPhp81Test.php
+++ b/tests/SerializerPhp81Test.php
@@ -386,7 +386,30 @@ test('function attributes with arguments', function () {
         fn ($attribute) => $attribute
             ->getName()->toBe(MyAttribute::class)
             ->getArguments()->toBe([
-                'My " \' Argument 1', Model::class,
+                'My " \' Argument 1', 'Tests\Fixtures\Model',
+            ])
+    );
+
+    expect($f())->toBeFalse();
+})->with('serializers');
+
+test('function attributes with array arguments', function () {
+    $model = new Model();
+
+    $f = #[MyAttribute("My Argument", ["one", "two"])] function () {
+        return false;
+    };
+
+    $f = s($f);
+
+    $reflector = new ReflectionFunction($f);
+
+    expect($reflector->getAttributes())->sequence(
+        fn ($attribute) => $attribute
+            ->getName()->toBe(MyAttribute::class)
+            ->getArguments()->toBe([
+                "My Argument",
+                ["one", "two"],
             ])
     );
 
@@ -571,12 +594,12 @@ test('function attributes with named arguments', function () {
             ->getName()->toBe(MyAttribute::class)
             ->getArguments()->toBe([
                 'string' => 'My " \' Argument 1',
-                'model' => Model::class,
+                'model' => 'Tests\\Fixtures\\Model',
             ]);
 
         expect($attribute->value->newInstance())
             ->string->toBe('My " \' Argument 1')
-            ->model->toBe(Model::class);
+            ->model->toBe('Tests\\Fixtures\\Model');
     });
 
     expect($f())->toBeFalse();
@@ -596,7 +619,7 @@ test('function attributes with first-class callable with methods', function () {
         fn ($attribute) => $attribute
             ->getName()->toBe(MyAttribute::class)
             ->getArguments()->toBe([
-                'My " \' Argument 1', Model::class,
+                'My " \' Argument 1', 'Tests\\Fixtures\\Model',
             ])
     );
 


### PR DESCRIPTION
This PR adds support for attributes that use `array` as arguments. Currently, this would fail with an `array to string conversion` error.