### PR TITLE
Remove setAccessible call for class properties (PHP 8.5)

### DIFF
--- a/src/Serializers/Native.php
+++ b/src/Serializers/Native.php
@@ -273,8 +273,6 @@ class Native implements Serializable
                         continue;
                     }
 
-                    $property->setAccessible(true);
-
                     if (! $property->isInitialized($instance)) {
                         continue;
                     }


### PR DESCRIPTION
Removed unnecessary call to setAccessible on property. 
Since PHP 8.1 it is not needed. 
Since PHP 8.5 it is deprecated.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
