### PR TITLE
Fix virtual property serialization

### DIFF
--- a/src/Serializers/Native.php
+++ b/src/Serializers/Native.php
@@ -269,7 +269,7 @@ class Native implements Serializable
                 }
 
                 foreach ($reflection->getProperties() as $property) {
-                    if ($property->isStatic() || ! $property->getDeclaringClass()->isUserDefined()) {
+                    if ($property->isStatic() || ! $property->getDeclaringClass()->isUserDefined() || static::isVirtualProperty($property)) {
                         continue;
                     }
 
@@ -367,7 +367,7 @@ class Native implements Serializable
                 }
 
                 foreach ($reflection->getProperties() as $property) {
-                    if ($property->isStatic() || ! $property->getDeclaringClass()->isUserDefined()) {
+                    if ($property->isStatic() || ! $property->getDeclaringClass()->isUserDefined() || static::isVirtualProperty($property)) {
                         continue;
                     }
 
@@ -487,7 +487,7 @@ class Native implements Serializable
                 }
 
                 foreach ($reflection->getProperties() as $property) {
-                    if ($property->isStatic() || ! $property->getDeclaringClass()->isUserDefined() || $this->isVirtualProperty($property)) {
+                    if ($property->isStatic() || ! $property->getDeclaringClass()->isUserDefined() || static::isVirtualProperty($property)) {
                         continue;
                     }
 
@@ -513,7 +513,7 @@ class Native implements Serializable
      * @param  \ReflectionProperty  $property
      * @return bool
      */
-    protected function isVirtualProperty(ReflectionProperty $property): bool
+    protected static function isVirtualProperty(ReflectionProperty $property): bool
     {
         return method_exists($property, 'isVirtual') && $property->isVirtual();
     }

--- a/tests/Php84Test.php
+++ b/tests/Php84Test.php
@@ -1,19 +1,52 @@
 <?php
 
-it('can serialize class with virtual property', function () {
-    $c = new VirtualPropWithPhp84();
+it('can serialize class with virtual properties', function () {
+    $binding = new ClosureBinding();
 
-    $f = function () use ($c) {
-        return $c;
-    };
+    $f = $binding->closure;
 
     $s1 = s($f);
 
-    expect('test')->toBe($s1()->test);
+    $result = $s1();
+
+    expect($result->virtualString)->toBe('virtual string')
+        ->and($result->virtualArray)->toBe(['virtual array'])
+        ->and($result->virtualObject)->toBeInstanceOf(VirtualObjectWithPhp84::class);
 })->with('serializers');
 
-class VirtualPropWithPhp84 {
-    public string $test {
-        get => 'test';
+/**
+ * Has a bound closure.
+ *
+ * This bound closure is needed to test `wrapClosures()` of `Native` and ensure it handles
+ * virtual properties correctly.
+ */
+class ClosureBinding {
+    public Closure $closure {
+        get {
+            $virtualProps = new VirtualPropWithPhp84();
+
+            return function () use ($virtualProps) {
+                // This binds the closure to `$this`
+                $this;
+
+                return $virtualProps;
+            };
+        }
     }
 }
+
+class VirtualPropWithPhp84 {
+    public string $virtualString {
+        get => 'virtual string';
+    }
+
+    public array $virtualArray {
+        get => ['virtual array'];
+    }
+
+    public VirtualObjectWithPhp84 $virtualObject {
+        get => new VirtualObjectWithPhp84();
+    }
+}
+
+class VirtualObjectWithPhp84 {}


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

#108 ensured that there isn't an attempt to modify virtual properties during serialization. However, since this isn't done in [`wrapClosures()`](https://github.com/jivanf/serializable-closure/blob/840d9d960d6d8e018b7ed5a833dae666c733c11a/src/Serializers/Native.php#L272) and [`mapPointers()`](https://github.com/jivanf/serializable-closure/blob/840d9d960d6d8e018b7ed5a833dae666c733c11a/src/Serializers/Native.php#L370), this fix doesn't handle the following cases:
- The closure containing an object with virtual properties is bound to another object. This calls `wrapClosures()` which always updates properties.
- At least one virtual property returns an array or an object. `mapPointers()` only updates properties when the value is an array or an object.

This PR uses the same virtual property check added to `mapByReference()` in #108. The method was made static because `wrapClosures()` is static.
