### PR TITLE
fix: cannot assign Native to property of type Closure

### DIFF
--- a/src/Serializers/Native.php
+++ b/src/Serializers/Native.php
@@ -255,7 +255,7 @@ class Native implements Serializable
             $instance = $data;
             $reflection = new ReflectionObject($instance);
 
-            if (! $reflection->isUserDefined()) {
+            if (! $reflection->isUserDefined() || $reflection->hasMethod('__serialize')) {
                 $storage[$instance] = $data;
 
                 return;
@@ -473,7 +473,7 @@ class Native implements Serializable
 
             $reflection = new ReflectionObject($data);
 
-            if (! $reflection->isUserDefined()) {
+            if (! $reflection->isUserDefined() || $reflection->hasMethod('__serialize')) {
                 $this->scope[$instance] = $data;
 
                 return;

--- a/tests/Fixtures/ClassWithTypedClosureProperty.php
+++ b/tests/Fixtures/ClassWithTypedClosureProperty.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tests\Fixtures;
+
+use Closure;
+use Laravel\SerializableClosure\SerializableClosure;
+
+class ClassWithTypedClosureProperty
+{
+    public Closure $callback;
+
+    public function __construct(?Closure $callback = null)
+    {
+        $this->callback = $callback ?? fn () => 'default';
+    }
+
+    public function call(): mixed
+    {
+        return ($this->callback)();
+    }
+
+    public function __serialize(): array
+    {
+        return ['callback' => new SerializableClosure($this->callback)];
+    }
+
+    public function __unserialize(array $data): void
+    {
+        $this->callback = $data['callback']->getClosure();
+    }
+}

--- a/tests/TypedClosurePropertyTest.php
+++ b/tests/TypedClosurePropertyTest.php
@@ -1,0 +1,25 @@
+<?php
+
+use Tests\Fixtures\ClassWithTypedClosureProperty;
+
+test('respect serialization of typed Closure property via use', function () {
+    $obj = new ClassWithTypedClosureProperty(fn () => 'custom');
+
+    $closure = function () use ($obj) {
+        return $obj->call();
+    };
+
+    expect(s($closure))->toBeInstanceOf(Closure::class);
+    expect(s($closure)())->toBe('custom');
+})->with('serializers');
+
+test('respect serialization of typed Closure property via $this binding', function () {
+    $obj = new ClassWithTypedClosureProperty(fn () => 'from binding');
+
+    $closure = Closure::bind(function () {
+        return $this->call();
+    }, $obj, ClassWithTypedClosureProperty::class);
+
+    expect(s($closure))->toBeInstanceOf(Closure::class);
+    expect(s($closure)())->toBe('from binding');
+})->with('serializers');


### PR DESCRIPTION
Hello!

When an object is serialized, all of its properties are recursively walked using reflection to wrap any closures. However, when an object has a property that's typed as `Closure` this causes a TypeError to be thrown (`cannot assign Native to property of type Closure`)---even on objects that implement `__serialize` and explicitly handle the closure.

The fix is to simply check if an object implements `__serialize` and if so, defer to that method for serialization instead of trying to still walk its properties.


Thanks!
