### PR TITLE
Fix trying to access array offset on null

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -20,6 +20,7 @@
             <file>tests/ReflectionClosureNonBracedNamespaceTest.php</file>
             <file>tests/SerializerTest.php</file>
             <file>tests/SignedSerializerTest.php</file>
+            <file>tests/ReflectionClosureEmptyTokensTest.php</file>
         </testsuite>
         <testsuite name="php81">
             <file phpVersion="8.1.0" phpVersionOperator=">=">tests/ReflectionClosurePhp80Test.php</file>

--- a/src/Support/ReflectionClosure.php
+++ b/src/Support/ReflectionClosure.php
@@ -737,6 +737,7 @@ class ReflectionClosure extends ReflectionFunction
         }
 
         $lastItem = array_pop($candidates);
+
         if ($lastItem) {
             $this->applyCandidate($lastItem);
             $code = $lastItem['code'];

--- a/src/Support/ReflectionClosure.php
+++ b/src/Support/ReflectionClosure.php
@@ -737,10 +737,20 @@ class ReflectionClosure extends ReflectionFunction
         }
 
         $lastItem = array_pop($candidates);
+        if ($lastItem) {
+            $this->applyCandidate($lastItem);
+            $code = $lastItem['code'];
+        } else {
+            if ($isShortClosure) {
+                $this->useVariables = $this->getStaticVariables();
+            } else {
+                $this->useVariables = empty($use) ? $use : array_intersect_key($this->getStaticVariables(), array_flip($use));
+            }
 
-        $this->applyCandidate($lastItem);
-
-        $code = $lastItem['code'];
+            $this->isShortClosure = $isShortClosure;
+            $this->isBindingRequired = $isUsingThisObject;
+            $this->isScopeRequired = $isUsingScope;
+        }
 
         if (! empty($attributesCode)) {
             $code = implode("\n", array_merge($attributesCode, [$code]));

--- a/tests/ReflectionClosureEmptyTokensTest.php
+++ b/tests/ReflectionClosureEmptyTokensTest.php
@@ -46,7 +46,8 @@ test('getUseVariables returns empty array when getTokens returns empty array', f
 });
 
 test('isStatic returns false when getTokens returns empty array', function () {
-    $closure = function () {};
+    $closure = function () {
+    };
 
     $rc = new EmptyTokensReflectionClosure($closure);
 
@@ -62,4 +63,3 @@ test('isShortClosure returns false when getTokens returns empty array', function
     // getCode() returns '' → trim('') === '' → substr('', 0, 2) !== 'fn'
     expect($rc->isShortClosure())->toBeFalse();
 });
-

--- a/tests/ReflectionClosureEmptyTokensTest.php
+++ b/tests/ReflectionClosureEmptyTokensTest.php
@@ -1,0 +1,65 @@
+<?php
+
+use Laravel\SerializableClosure\Support\ReflectionClosure;
+
+/**
+ * A subclass that overrides getFileTokens() to return an empty array,
+ * simulating the condition where getTokens() produces [].
+ */
+class EmptyTokensReflectionClosure extends ReflectionClosure
+{
+    protected function getFileTokens(): array
+    {
+        return [];
+    }
+}
+
+test('getTokens returns empty array when getFileTokens returns empty array', function () {
+    $closure = function () {
+        return 42;
+    };
+
+    $rc = new EmptyTokensReflectionClosure($closure);
+
+    // Access the protected getTokens() via getCode(), which iterates over the tokens.
+    // With no tokens the for-loop never runs, so no candidates are collected.
+    // $lastItem = array_pop([]) === null → the else branch runs, setting
+    // isShortClosure / isBindingRequired / isScopeRequired but leaving $code = ''.
+    $code = $rc->getCode();
+
+    expect($code)->toBe('');
+});
+
+test('getUseVariables returns empty array when getTokens returns empty array', function () {
+    $x = 1;
+    $closure = function () use ($x) {
+        return $x;
+    };
+
+    $rc = new EmptyTokensReflectionClosure($closure);
+
+    // getUseVariables() iterates tokens looking for T_USE; with no tokens the
+    // loop body never runs, so $use stays [] and useVariables is set to [].
+    $useVars = $rc->getUseVariables();
+
+    expect($useVars)->toBe([]);
+});
+
+test('isStatic returns false when getTokens returns empty array', function () {
+    $closure = function () {};
+
+    $rc = new EmptyTokensReflectionClosure($closure);
+
+    // getCode() returns '' → substr('', 0, 6) === '' which is not 'static'
+    expect($rc->isStatic())->toBeFalse();
+});
+
+test('isShortClosure returns false when getTokens returns empty array', function () {
+    $closure = fn () => 42;
+
+    $rc = new EmptyTokensReflectionClosure($closure);
+
+    // getCode() returns '' → trim('') === '' → substr('', 0, 2) !== 'fn'
+    expect($rc->isShortClosure())->toBeFalse();
+});
+


### PR DESCRIPTION
Closes #123 

@michaelruelas introduced a regression in https://github.com/laravel/serializable-closure/pull/120. The code assumes `getTokens()` returns a `non-empty-array`, in cases where `[]` is returned the following error occurs:
```
Trying to access array offset on null {"exception":"[object] (ErrorException(code: 0): Trying to access array offset on null at /vendor/laravel/serializable-closure/src/Support/ReflectionClosure.php:1335)
[stacktrace]
#0 /vendor/laravel/framework/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php(258): Illuminate\\Foundation\\Bootstrap\\HandleExceptions->handleError()
#1 /vendor/laravel/serializable-closure/src/Support/ReflectionClosure.php(1335): Illuminate\\Foundation\\Bootstrap\\HandleExceptions->{closure:Illuminate\\Foundation\\Bootstrap\\HandleExceptions::forwardsTo():257}()
#2 /vendor/laravel/serializable-closure/src/Support/ReflectionClosure.php(743): Laravel\\SerializableClosure\\Support\\ReflectionClosure->applyCandidate()
#3 /vendor/laravel/serializable-closure/src/Support/ReflectionClosure.php(819): Laravel\\SerializableClosure\\Support\\ReflectionClosure->getCode()
#4 /vendor/laravel/serializable-closure/src/Serializers/Native.php(122): Laravel\\SerializableClosure\\Support\\ReflectionClosure->isBindingRequired()
#5 [internal function]: Laravel\\SerializableClosure\\Serializers\\Native->__serialize()
#6 /vendor/laravel/serializable-closure/src/Serializers/Signed.php(68): serialize()
#7 [internal function]: Laravel\\SerializableClosure\\Serializers\\Signed->__serialize()
#8 /vendor/laravel/framework/src/Illuminate/Bus/DatabaseBatchRepository.php(333): serialize()
#9 /vendor/laravel/framework/src/Illuminate/Bus/DatabaseBatchRepository.php(106): Illuminate\\Bus\\DatabaseBatchRepository->serialize()
#10 /vendor/laravel/framework/src/Illuminate/Bus/PendingBatch.php(463): Illuminate\\Bus\\DatabaseBatchRepository->store()
#11 /vendor/laravel/framework/src/Illuminate/Bus/PendingBatch.php(372): Illuminate\\Bus\\PendingBatch->store()
```

