### PR TITLE
test: add failing tests for #126 — objects with __serialize and closure array properties

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -31,5 +31,9 @@
         <testsuite name="php84">
             <file phpVersion="8.4.0" phpVersionOperator=">=">tests/Php84Test.php</file>
         </testsuite>
+        <testsuite name="serializer-regression">
+            <file>tests/TypedClosurePropertyTest.php</file>
+            <file>tests/SerializeObjectWithClosureArrayPropertyTest.php</file>
+        </testsuite>
     </testsuites>
 </phpunit>

--- a/tests/Fixtures/ClassWithSerializeAndClosureArrayProperty.php
+++ b/tests/Fixtures/ClassWithSerializeAndClosureArrayProperty.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Tests\Fixtures;
+
+class ClassWithSerializeAndClosureArrayProperty
+{
+    public string $name = 'test';
+    /** @var \Closure[] */
+    public array $callbacks = [];
+
+    public function __serialize(): array
+    {
+        return [
+            'name' => $this->name,
+            'callbacks' => $this->callbacks,
+        ];
+    }
+
+    public function __unserialize(array $data): void
+    {
+        $this->name = $data['name'];
+        $this->callbacks = $data['callbacks'];
+    }
+}

--- a/tests/SerializeObjectWithClosureArrayPropertyTest.php
+++ b/tests/SerializeObjectWithClosureArrayPropertyTest.php
@@ -1,0 +1,37 @@
+<?php
+
+use Tests\Fixtures\ClassWithSerializeAndClosureArrayProperty;
+
+test('closure use variable referencing object with __serialize and closure array property', function () {
+    $obj = new ClassWithSerializeAndClosureArrayProperty();
+    $obj->callbacks[] = fn () => 'callback result';
+
+    $closure = function () use ($obj) {
+        return $obj->name;
+    };
+
+    expect(s($closure)())->toBe('test');
+})->with('serializers');
+
+test('closure bound to object with __serialize and closure array property', function () {
+    $obj = new ClassWithSerializeAndClosureArrayProperty();
+    $obj->callbacks[] = fn () => 'callback result';
+
+    $closure = Closure::bind(function () {
+        return $this->name;
+    }, $obj, ClassWithSerializeAndClosureArrayProperty::class);
+
+    expect(s($closure)())->toBe('test');
+})->with('serializers');
+
+test('closure use variable referencing object with __serialize preserves closure array values', function () {
+    $obj = new ClassWithSerializeAndClosureArrayProperty();
+    $obj->callbacks[] = fn () => 'first';
+    $obj->callbacks[] = fn () => 'second';
+
+    $closure = function () use ($obj) {
+        return array_map(fn ($cb) => $cb(), $obj->callbacks);
+    };
+
+    expect(s($closure)())->toBe(['first', 'second']);
+})->with('serializers');


### PR DESCRIPTION
## Summary

Adds failing test cases for #126 — objects implementing `__serialize` that have closures in array properties (or other non-typed-`Closure` properties) fail to serialize since v2.0.9.

## Tests added

| Test | Description |
|------|-------------|
| `closure use variable referencing object with __serialize and closure array property` | Closure captures the object via `use` |
| `closure bound to object with __serialize and closure array property` | Closure bound to the object via `$this` |
| `closure use variable referencing object with __serialize preserves closure array values` | Round-trip preserving the closure array values |

All 9 tests (3 cases × 3 serializers: Native, Signed, Unsigned) currently fail with `Serialization of 'Closure' is not allowed`.

## `phpunit.xml.dist` fix

The new test file and the existing `TypedClosurePropertyTest.php` (added in #122) were both missing from `phpunit.xml.dist`, which uses explicit `<file>` entries rather than directory scanning. This meant those tests were never executed in CI. This PR adds both to a new `serializer-regression` test suite in the config.

## Root cause

The `wrapClosures()` / `mapByReference()` change in #122 skips all objects with `__serialize`, so nested closures inside those objects are never wrapped with `Native` instances. When PHP later calls `__serialize()`, the raw `\Closure` values pass through and hit PHP's native serialization restriction.

Note: this is distinct from the `TypedClosurePropertyTest` cases which pass because `ClassWithTypedClosureProperty` manually wraps its closure in `SerializableClosure` inside `__serialize()`. The new fixture (`ClassWithSerializeAndClosureArrayProperty`) does *not* manually wrap — it just returns its properties as-is, which is the common case for user-defined classes that aren't aware of `laravel/serializable-closure`.

Ref: #126