### PR TITLE
[2.x] [bug] Fix crash with method-only attributes on serialized closures

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -27,6 +27,7 @@
             <file phpVersion="8.1.0" phpVersionOperator=">=">tests/ReflectionClosurePhp81Test.php</file>
             <file phpVersion="8.1.0" phpVersionOperator=">=">tests/SerializerPhp80Test.php</file>
             <file phpVersion="8.1.0" phpVersionOperator=">=">tests/SerializerPhp81Test.php</file>
+            <file phpVersion="8.1.0" phpVersionOperator=">=">tests/MethodOnlyAttributeTest.php</file>
         </testsuite>
         <testsuite name="php84">
             <file phpVersion="8.4.0" phpVersionOperator=">=">tests/Php84Test.php</file>

--- a/src/Support/ReflectionClosure.php
+++ b/src/Support/ReflectionClosure.php
@@ -695,10 +695,27 @@ class ReflectionClosure extends ReflectionFunction
             }
         }
 
-        $attributesCode = array_map(function ($attribute) {
-            $arguments = $attribute->getArguments();
-
+        $attributesCode = array_values(array_filter(array_map(function ($attribute) {
             $name = $attribute->getName();
+
+            // Skip attributes that cannot target functions. When a closure is
+            // created from a method (e.g. `$obj->method(...)`), the method's
+            // attributes are inherited. Attributes that only target methods
+            // (like #[\Override]) would cause a fatal error when applied to
+            // the serialized closure function.
+            if (class_exists($name)) {
+                $ref = new \ReflectionClass($name);
+                $attrAttributes = $ref->getAttributes(\Attribute::class);
+
+                if (! empty($attrAttributes)) {
+                    $flags = $attrAttributes[0]->getArguments()[0] ?? \Attribute::TARGET_ALL;
+                    if (($flags & \Attribute::TARGET_FUNCTION) === 0) {
+                        return null;
+                    }
+                }
+            }
+
+            $arguments = $attribute->getArguments();
             $arguments = implode(', ', array_map(function ($argument, $key) {
                 $argument = var_export($argument, true);
 
@@ -710,7 +727,7 @@ class ReflectionClosure extends ReflectionFunction
             }, $arguments, array_keys($arguments)));
 
             return "#[$name($arguments)]";
-        }, $this->getAttributes());
+        }, $this->getAttributes())));
 
         if (count($candidates) > 1) {
             $lastItem = array_pop($candidates);

--- a/tests/MethodOnlyAttributeTest.php
+++ b/tests/MethodOnlyAttributeTest.php
@@ -17,19 +17,25 @@ it('preserves attributes that can target functions', function () {
 })->with('serializers');
 
 #[\Attribute(\Attribute::TARGET_METHOD)]
-class MethodOnlyAttribute {}
+class MethodOnlyAttribute
+{
+}
 
 #[\Attribute(\Attribute::TARGET_FUNCTION | \Attribute::TARGET_METHOD)]
-class FunctionTargetableAttribute {}
+class FunctionTargetableAttribute
+{
+}
 
-class ParentClassForOverride {
+class ParentClassForOverride
+{
     public function test(): string
     {
         return '';
     }
 }
 
-class ChildClassWithOverride extends ParentClassForOverride {
+class ChildClassWithOverride extends ParentClassForOverride
+{
     #[\Override]
     public function test(): string
     {
@@ -37,7 +43,8 @@ class ChildClassWithOverride extends ParentClassForOverride {
     }
 }
 
-class ClassWithFunctionTargetableAttribute {
+class ClassWithFunctionTargetableAttribute
+{
     #[FunctionTargetableAttribute]
     public function test(): string
     {

--- a/tests/MethodOnlyAttributeTest.php
+++ b/tests/MethodOnlyAttributeTest.php
@@ -1,0 +1,46 @@
+<?php
+
+it('can serialize closures from methods with method-only attributes', function () {
+    $closure = (new ChildClassWithOverride)->test(...);
+
+    $unserialized = s($closure);
+
+    expect($unserialized())->toBe('hello');
+})->with('serializers');
+
+it('preserves attributes that can target functions', function () {
+    $closure = (new ClassWithFunctionTargetableAttribute)->test(...);
+
+    $code = (new \Laravel\SerializableClosure\Support\ReflectionClosure($closure))->getCode();
+
+    expect($code)->toContain('FunctionTargetableAttribute');
+})->with('serializers');
+
+#[\Attribute(\Attribute::TARGET_METHOD)]
+class MethodOnlyAttribute {}
+
+#[\Attribute(\Attribute::TARGET_FUNCTION | \Attribute::TARGET_METHOD)]
+class FunctionTargetableAttribute {}
+
+class ParentClassForOverride {
+    public function test(): string
+    {
+        return '';
+    }
+}
+
+class ChildClassWithOverride extends ParentClassForOverride {
+    #[\Override]
+    public function test(): string
+    {
+        return 'hello';
+    }
+}
+
+class ClassWithFunctionTargetableAttribute {
+    #[FunctionTargetableAttribute]
+    public function test(): string
+    {
+        return 'world';
+    }
+}


### PR DESCRIPTION
## Summary

Fixes a crash when deserializing closures created from class methods that have method-only attributes (like `#[Override]`). The serializer incorrectly includes these attributes in the generated closure code, but they are not valid on functions, causing a fatal error.

Fixes laravel/serializable-closure#110

## Problem

When a closure is extracted from a class method decorated with `#[Override]`, the serializer copies all method attributes into the serialized closure representation. On deserialization, PHP rejects `#[Override]` (and other method-only attributes) because the target is now a function, not a method:

```php
class MyClass {
    #[\Override]
    public function handle(): void { ... }
}

// Serializing a closure from this method includes #[\Override]
// Deserializing fails: Attribute "Override" cannot target function
```

## Solution

Filter out attributes whose target flags do not include `Attribute::TARGET_FUNCTION` before including them in the serialized closure code. Attributes that can validly target functions are preserved.

## Test Plan

- [x] Added test for `#[Override]` attribute on parent method (exact reproduction case from the issue)
- Added test verifying attributes that can target functions are still preserved
- [x] Existing test suite passes with no regressions