### PR TITLE
[2.x] [maintenance] Switch phpunit.xml.dist to directory scanning for test discovery

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,26 +11,11 @@
          backupStaticProperties="false">
     <testsuites>
         <testsuite name="Tests">
-            <file>tests/ReflectionClosure1Test.php</file>
-            <file>tests/ReflectionClosure2Test.php</file>
-            <file>tests/ReflectionClosure3Test.php</file>
-            <file>tests/ReflectionClosure4Test.php</file>
-            <file>tests/ReflectionClosure5Test.php</file>
-            <file>tests/ReflectionClosureBracedNamespaceTest.php</file>
-            <file>tests/ReflectionClosureNonBracedNamespaceTest.php</file>
-            <file>tests/SerializerTest.php</file>
-            <file>tests/SignedSerializerTest.php</file>
-            <file>tests/ReflectionClosureEmptyTokensTest.php</file>
-            <file>tests/TypedClosurePropertyTest.php</file>
-            <file>tests/SerializeNestedClosureRegressionTest.php</file>
-            <file>tests/InstanceofExpressionTest.php</file>
-        </testsuite>
-        <testsuite name="php81">
-            <file phpVersion="8.1.0" phpVersionOperator=">=">tests/ReflectionClosurePhp80Test.php</file>
-            <file phpVersion="8.1.0" phpVersionOperator=">=">tests/ReflectionClosurePhp81Test.php</file>
-            <file phpVersion="8.1.0" phpVersionOperator=">=">tests/SerializerPhp80Test.php</file>
-            <file phpVersion="8.1.0" phpVersionOperator=">=">tests/SerializerPhp81Test.php</file>
-            <file phpVersion="8.1.0" phpVersionOperator=">=">tests/MethodOnlyAttributeTest.php</file>
+            <directory suffix="Test.php">tests</directory>
+            <!-- Excluded because these files use PHP syntax (true type, property hooks) that causes
+                 parse errors on lower PHP versions. They run in version-gated suites below. -->
+            <exclude>tests/TrueTypeTest.php</exclude>
+            <exclude>tests/Php84Test.php</exclude>
         </testsuite>
         <testsuite name="php82">
             <file phpVersion="8.2.0" phpVersionOperator=">=">tests/TrueTypeTest.php</file>


### PR DESCRIPTION
Fixes #132

## Summary

Switch from explicit `<file>` entries to `<directory>` scanning so new tests are automatically discovered without needing to update `phpunit.xml.dist`.

`TrueTypeTest.php` and `Php84Test.php` are excluded from the main suite because they use PHP 8.2+ and 8.4+ syntax respectively, which would cause parse errors on lower PHP versions. They run in their own version-gated suites instead.

## Problem

Tests have been added to `tests/` without being registered in `phpunit.xml.dist` multiple times. `TypedClosurePropertyTest.php` and `SerializeNestedClosureRegressionTest.php` were both missed and had to be registered after the fact (47b2c19), and `MultipleClosuresOnSameLineTest.php` is still not registered today. This change ensures every test file runs by default unless explicitly excluded or version-gated, to avoid this kind of mistake in the future.

## Test plan

- [x] Full test suite passes locally
- [x] `MultipleClosuresOnSameLineTest` now discovered and runs (+6 tests across all PHP versions)
- [x] Version-gated tests (`TrueTypeTest`, `Php84Test`) run only on compatible PHP versions
- [x] Tested locally against the full CI matrix, zero failures:

| PHP | Tests | Result |
|---|---|---|
| 8.1 | 370 passed, 1 skipped | Pass |
| 8.2 | 373 passed, 1 skipped | Pass |
| 8.3 | 373 passed, 1 skipped | Pass |
| 8.4 | 376 passed, 1 skipped | Pass |
| 8.5 | 376 passed, 1 skipped | Pass |

The 1 skipped test (`final class constants`) is a pre-existing upstream skip due to a PHP limitation (constants in anonymous classes are not supported).