### PR TITLE
[2.x] [bug] Fix closures on same line losing identity after serialization

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -25,6 +25,7 @@
             <file>tests/SerializeNestedClosureRegressionTest.php</file>
             <file>tests/InstanceofExpressionTest.php</file>
             <file>tests/MultipleClosuresOnSameLineTest.php</file>
+            <file>tests/ClosureArrayIdentityTest.php</file>
         </testsuite>
         <testsuite name="php81">
             <file phpVersion="8.1.0" phpVersionOperator=">=">tests/ReflectionClosurePhp80Test.php</file>

--- a/src/Support/ReflectionClosure.php
+++ b/src/Support/ReflectionClosure.php
@@ -4,6 +4,7 @@ namespace Laravel\SerializableClosure\Support;
 
 use Closure;
 use ReflectionFunction;
+use WeakMap;
 
 class ReflectionClosure extends ReflectionFunction
 {
@@ -15,12 +16,22 @@ class ReflectionClosure extends ReflectionFunction
     protected $isScopeRequired;
     protected $isBindingRequired;
     protected $isShortClosure;
+    protected $closureObject;
 
     protected static $files = [];
     protected static $classes = [];
     protected static $functions = [];
     protected static $constants = [];
     protected static $structures = [];
+
+    /**
+     * Tracks which candidate index has been assigned to each closure object
+     * for a given file:line, so that multiple closures on the same line with
+     * identical signatures can be distinguished.
+     *
+     * @var \WeakMap<\Closure, array{location: string, index: int}>|null
+     */
+    protected static $candidateMap;
 
     /**
      * Creates a new reflection closure instance.
@@ -32,6 +43,7 @@ class ReflectionClosure extends ReflectionFunction
     public function __construct(Closure $closure, $code = null)
     {
         parent::__construct($closure);
+        $this->closureObject = $closure;
     }
 
     /**
@@ -735,16 +747,19 @@ class ReflectionClosure extends ReflectionFunction
         }, $this->getAttributes())));
 
         if (count($candidates) > 1) {
-            $lastItem = array_pop($candidates);
-
+            // Collect all candidates that match the closure's signature.
+            $matchingCandidates = [];
             foreach ($candidates as $candidate) {
-                if (! $this->verifyCandidateSignature($candidate)) {
-                    continue;
+                if ($this->verifyCandidateSignature($candidate)) {
+                    $matchingCandidates[] = $candidate;
                 }
+            }
 
-                $this->applyCandidate($candidate);
+            if (count($matchingCandidates) === 1) {
+                // Only one candidate matches - use it directly.
+                $this->applyCandidate($matchingCandidates[0]);
 
-                $code = $candidate['code'];
+                $code = $matchingCandidates[0]['code'];
 
                 if (! empty($attributesCode)) {
                     $code = implode("\n", array_merge($attributesCode, [$code]));
@@ -755,7 +770,25 @@ class ReflectionClosure extends ReflectionFunction
                 return $this->code;
             }
 
-            $candidates[] = $lastItem;
+            if (count($matchingCandidates) > 1) {
+                // Multiple candidates with identical signatures on the same line.
+                // Use a WeakMap counter to assign each closure object a unique index
+                // so that closures are matched in the order they appear in the source.
+                $candidateIndex = $this->resolveCandidateIndex($matchingCandidates);
+                $selected = $matchingCandidates[$candidateIndex];
+
+                $this->applyCandidate($selected);
+
+                $code = $selected['code'];
+
+                if (! empty($attributesCode)) {
+                    $code = implode("\n", array_merge($attributesCode, [$code]));
+                }
+
+                $this->code = $code;
+
+                return $this->code;
+            }
         }
 
         $lastItem = array_pop($candidates);
@@ -1374,6 +1407,48 @@ class ReflectionClosure extends ReflectionFunction
         $this->isShortClosure = $candidate['isShortClosure'];
         $this->isBindingRequired = $candidate['isUsingThisObject'];
         $this->isScopeRequired = $candidate['isUsingScope'];
+    }
+
+    /**
+     * Resolve which candidate index this closure should use when multiple
+     * candidates on the same source line have identical signatures.
+     *
+     * Uses a static WeakMap to track which closure objects have already been
+     * assigned a candidate index for a given file:line, so that each closure
+     * gets a unique candidate in source order.
+     *
+     * @param  array  $matchingCandidates
+     * @return int
+     */
+    protected function resolveCandidateIndex($matchingCandidates)
+    {
+        if (static::$candidateMap === null) {
+            static::$candidateMap = new WeakMap;
+        }
+
+        // Check if this closure already has an assigned index.
+        if (isset(static::$candidateMap[$this->closureObject])) {
+            return static::$candidateMap[$this->closureObject]['index'];
+        }
+
+        // Count how many closures from this file:line have already been assigned.
+        $locationKey = $this->getFileName().':'.$this->getStartLine();
+        $usedIndices = 0;
+
+        foreach (static::$candidateMap as $closure => $data) {
+            if (($data['location'] ?? null) === $locationKey) {
+                $usedIndices++;
+            }
+        }
+
+        $index = min($usedIndices, count($matchingCandidates) - 1);
+
+        static::$candidateMap[$this->closureObject] = [
+            'location' => $locationKey,
+            'index' => $index,
+        ];
+
+        return $index;
     }
 
     /**

--- a/src/Support/ReflectionClosure.php
+++ b/src/Support/ReflectionClosure.php
@@ -24,13 +24,6 @@ class ReflectionClosure extends ReflectionFunction
     protected static $constants = [];
     protected static $structures = [];
 
-    /**
-     * Tracks which candidate index has been assigned to each closure object
-     * for a given file:line, so that multiple closures on the same line with
-     * identical signatures can be distinguished.
-     *
-     * @var \WeakMap<\Closure, array{location: string, index: int}>|null
-     */
     protected static $candidateMap;
 
     /**
@@ -771,9 +764,6 @@ class ReflectionClosure extends ReflectionFunction
             }
 
             if (count($matchingCandidates) > 1) {
-                // Multiple candidates with identical signatures on the same line.
-                // Use a WeakMap counter to assign each closure object a unique index
-                // so that closures are matched in the order they appear in the source.
                 $candidateIndex = $this->resolveCandidateIndex($matchingCandidates);
                 $selected = $matchingCandidates[$candidateIndex];
 
@@ -1410,12 +1400,7 @@ class ReflectionClosure extends ReflectionFunction
     }
 
     /**
-     * Resolve which candidate index this closure should use when multiple
-     * candidates on the same source line have identical signatures.
-     *
-     * Uses a static WeakMap to track which closure objects have already been
-     * assigned a candidate index for a given file:line, so that each closure
-     * gets a unique candidate in source order.
+     * Resolve which candidate index this closure should use.
      *
      * @param  array  $matchingCandidates
      * @return int
@@ -1426,12 +1411,10 @@ class ReflectionClosure extends ReflectionFunction
             static::$candidateMap = new WeakMap;
         }
 
-        // Check if this closure already has an assigned index.
         if (isset(static::$candidateMap[$this->closureObject])) {
             return static::$candidateMap[$this->closureObject]['index'];
         }
 
-        // Count how many closures from this file:line have already been assigned.
         $locationKey = $this->getFileName().':'.$this->getStartLine();
         $usedIndices = 0;
 

--- a/src/Support/ReflectionClosure.php
+++ b/src/Support/ReflectionClosure.php
@@ -1424,7 +1424,7 @@ class ReflectionClosure extends ReflectionFunction
             }
         }
 
-        $index = min($usedIndices, count($matchingCandidates) - 1);
+        $index = $usedIndices % count($matchingCandidates);
 
         static::$candidateMap[$this->closureObject] = [
             'location' => $locationKey,

--- a/tests/ClosureArrayIdentityTest.php
+++ b/tests/ClosureArrayIdentityTest.php
@@ -1,0 +1,79 @@
+<?php
+
+use Laravel\SerializableClosure\SerializableClosure;
+
+test('multiple arrow closures in an array preserve identity after roundtrip', function () {
+    $closures = [fn () => 'a', fn () => 'b', fn () => 'c'];
+
+    $serialized = serialize(array_map(fn ($c) => new SerializableClosure($c), $closures));
+    $unserialized = unserialize($serialized);
+
+    expect($unserialized[0]())->toBe('a');
+    expect($unserialized[1]())->toBe('b');
+    expect($unserialized[2]())->toBe('c');
+});
+
+test('two arrow closures on the same line with identical signatures', function () {
+    $closures = [fn () => 1, fn () => 2];
+
+    $serialized = serialize(array_map(fn ($c) => new SerializableClosure($c), $closures));
+    $unserialized = unserialize($serialized);
+
+    expect($unserialized[0]())->toBe(1);
+    expect($unserialized[1]())->toBe(2);
+});
+
+test('closures on different lines still work after roundtrip', function () {
+    $a = fn () => 'x';
+    $b = fn () => 'y';
+    $c = fn () => 'z';
+
+    $closures = [$a, $b, $c];
+    $serialized = serialize(array_map(fn ($c) => new SerializableClosure($c), $closures));
+    $unserialized = unserialize($serialized);
+
+    expect($unserialized[0]())->toBe('x');
+    expect($unserialized[1]())->toBe('y');
+    expect($unserialized[2]())->toBe('z');
+});
+
+test('single closure still works normally after roundtrip', function () {
+    $closure = fn () => 'hello';
+
+    $serialized = serialize(new SerializableClosure($closure));
+    $unserialized = unserialize($serialized);
+
+    expect($unserialized())->toBe('hello');
+});
+
+test('same-line closures with parameters preserve identity', function () {
+    $closures = [fn ($x) => $x * 2, fn ($x) => $x * 3, fn ($x) => $x + 1];
+
+    $serialized = serialize(array_map(fn ($c) => new SerializableClosure($c), $closures));
+    $unserialized = unserialize($serialized);
+
+    expect($unserialized[0](5))->toBe(10);
+    expect($unserialized[1](5))->toBe(15);
+    expect($unserialized[2](5))->toBe(6);
+});
+
+test('same-line static arrow closures preserve identity', function () {
+    $closures = [static fn () => 'first', static fn () => 'second'];
+
+    $serialized = serialize(array_map(fn ($c) => new SerializableClosure($c), $closures));
+    $unserialized = unserialize($serialized);
+
+    expect($unserialized[0]())->toBe('first');
+    expect($unserialized[1]())->toBe('second');
+});
+
+test('mixed signature closures on same line still disambiguate correctly', function () {
+    $closures = [fn () => 'no-args', fn ($a) => $a, fn () => 'also-no-args'];
+
+    $serialized = serialize(array_map(fn ($c) => new SerializableClosure($c), $closures));
+    $unserialized = unserialize($serialized);
+
+    expect($unserialized[0]())->toBe('no-args');
+    expect($unserialized[1]('test'))->toBe('test');
+    expect($unserialized[2]())->toBe('also-no-args');
+});


### PR DESCRIPTION
## Summary

Fixes #131 · Builds on #120

When multiple closures are defined on the same source line with identical signatures, they all silently resolve to the first closure after a serialize/unserialize roundtrip. No error is thrown, the wrong closure just runs.

**Works** (each closure on its own line):

```php
$closures = [
    fn() => 'a',
    fn() => 'b',
    fn() => 'c',
];

$serialized = serialize(array_map(fn($c) => new SerializableClosure($c), $closures));
$unserialized = array_map(fn($sc) => $sc->getClosure(), unserialize($serialized));

$unserialized[0](); // 'a' ✓
$unserialized[1](); // 'b' ✓
$unserialized[2](); // 'c' ✓
```

**Broken** (all closures on the same line):

```php
$closures = [fn() => 'a', fn() => 'b', fn() => 'c']; // <- inline causes the bug

$serialized = serialize(array_map(fn($c) => new SerializableClosure($c), $closures));
$unserialized = array_map(fn($sc) => $sc->getClosure(), unserialize($serialized));

$unserialized[0](); // 'a'
$unserialized[1](); // 'a' expected 'b'
$unserialized[2](); // 'a' expected 'c'
```

**Real-world example:**

A job chain written across multiple lines works fine because each closure is on its own line, so the tokenizer can distinguish them:

```php
Bus::chain([
    fn() => ProcessPayment::dispatch($order), // runs ProcessPayment ✓
    fn() => SendConfirmation::dispatch($order), // runs SendConfirmation ✓
    fn() => UpdateInventory::dispatch($order), // runs UpdateInventory ✓
])->dispatch();
```

But written compactly on a single line, which formatters may do, or developers writing inline:

```php
Bus::chain([fn() => ProcessPayment::dispatch($order), fn() => SendConfirmation::dispatch($order), fn() => UpdateInventory::dispatch($order)])->dispatch(); // <- inline causes the bug
// All three run ProcessPayment. Confirmation never sends, inventory never updates.
```

All three closures have the same signature (`fn()` with no params) and share the same source line. After serialization through the queue, all three resolve to `ProcessPayment::dispatch($order)`. Silently, with no error.

**Builds on:** PR #120 (merged Jan 8) introduced candidate collection for different-signature closures on the same line. This PR fixes the remaining gap: identical-signature closures.

**Upstream context:** This is a [documented caveat in opis/closure 4.x](https://opis.io/closure/4.x/caveats.html) -- PHP reflection only provides line numbers, not column numbers, so the upstream library considers this unfixable. However, this PR works around the PHP limitation using a `WeakMap` keyed by the closure object to assign unique candidate indices. The same fix has been proposed upstream as a proof of concept ([opis/closure#165](https://github.com/opis/closure/pull/165)).

**Real-world reports:**
- Issue #119: user hit this with `Concurrency::run([fn() => 1, fn() => 2])` returning `[1, 1]`. Confirmed by @crynobone as a limitation of line-based token parsing.
- PR #120 partially fixed different-signature closures, but @Niush immediately confirmed identical-signature closures still broke: `Concurrency::driver('process')->run([fn() => "a", fn() => "b"])` returns `["a", "a"]`.
- [frodeborli/serializor](https://github.com/frodeborli/serializor) (an opis/closure consumer) independently discovered this bug and built explicit exception-throwing detection as a workaround. While their report targets opis/closure, the root cause is identical -- both libraries use line-based token parsing to identify closures.

## Fix

Instead of returning the first signature match, collect **all** matching candidates. When multiple match, use a static `WeakMap` keyed by the closure object to assign each one a unique candidate index in source order. Single-match and zero-match paths are unchanged.

The `WeakMap` ensures entries are automatically cleaned up when closures are garbage collected, so there is no memory leak in long-running processes.

Candidate index selection uses **modulo arithmetic** (`$usedIndices % count($matchingCandidates)`) so the index always wraps within the valid range of candidates, rather than clamping to the last candidate via `min()`. This correctly cycles through candidates when there are more serialization calls than candidates.

## Known limitation

The fix covers all standard usage patterns. The only remaining edge case requires ALL four conditions simultaneously:

1. Multiple closures on the **same line**
2. With **identical signatures** (same params, same static/non-static)
3. In the **same batch** (closures from repeated invocations are handled correctly via modulo cycling)
4. Serialized in **deliberate out-of-array order** (e.g., `$closures[2]` before `$closures[0]`)

**What works:**

```php
// Sequential iteration (array_map, foreach, Bus::chain) ✓
$closures = [fn() => 'a', fn() => 'b', fn() => 'c'];
serialize(array_map(fn($c) => new SerializableClosure($c), $closures));

// Separate lines (any order) ✓
$a = fn() => 'a';
$b = fn() => 'b';
serialize(new SerializableClosure($b));
serialize(new SerializableClosure($a));

// Repeated invocations from the same line (modulo cycling) ✓
// e.g., test datasets, long-running processes
```

**What doesn't work:**

```php
// Same line + identical signatures + out-of-order index access
$closures = [fn() => 'a', fn() => 'b', fn() => 'c'];
serialize(new SerializableClosure($closures[2])); // gets wrong candidate
serialize(new SerializableClosure($closures[0])); // gets wrong candidate
```

An exception cannot be thrown for this case because PHP reflection provides no column number or source position for closures -- only line numbers. When the first closure from a line is serialized, there is no way to determine whether it is the first, second, or third closure on that line. The out-of-order case is indistinguishable from the sequential case at the point of serialization.

A search across 250+ public repositories found zero instances of this pattern. Anyone accessing closures by specific index already has them on separate lines.


## Testing

**In the PR:** 7 tests covering array identity, two closures, different lines, single closure, closures with parameters, static closures, and mixed signatures.

**Independent testing:** [93 test cases across 13 categories (61 comprehensive + 32 sanity suite)](https://github.com/JoshSalway/sc-136-tests) tested before and after the fix:

- Before fix (2.x base): **4 passed, 57 failed** (every same-line test fails)
- After fix (PR #136): **93 passed, 0 failed**
- Pest test suite: **377 passed, 0 failed**, no regressions

Categories tested: arrow functions (2-10 on same line), static closures, traditional closures with `use()`, typed/nullable/union/variadic params, return types, mixed return values, string/math/array operations, ternary/match/null coalescing, instanceof, object creation, closures returning closures, mixed signatures (#120 + #136 interplay), constants, serialization edge cases (re-serialization, individual serialization).

The sanity suite includes 32 parity tests: multi-line versions of each single-line test, independently validating that the bug is isolated to same-line closures only and that multi-line usage always works correctly.

## Test plan

- [x] Multiple arrow closures in array preserve identity after roundtrip
- [x] Two closures on same line with identical signatures
- [x] Closures on different lines still work
- [x] Single closure roundtrip unaffected
- [x] Same-line closures with parameters
- [x] Same-line static closures
- [x] Mixed-signature closures disambiguate correctly
- [x] All existing tests pass with no regressions
- [x] CI green across PHP 8.1-8.5, Laravel 10-13
- [x] StyleCI passed

**Future work:**
- Nested closures returned from arrow functions: #148

**Post-merge consideration:** If merged, consider documenting the known limitation (serialization order assumption for same-line closures) in the README or a caveats section, similar to how [opis/closure documents it](https://opis.io/closure/4.x/caveats.html). This helps users understand the edge case without having to read PR descriptions.




