### PR TITLE
[2.x] [bug] Fix operator precedence bug in scope detection for class keywords

### DIFF
--- a/src/Support/ReflectionClosure.php
+++ b/src/Support/ReflectionClosure.php
@@ -643,7 +643,7 @@ class ReflectionClosure extends ReflectionFunction
                                     $context === 'root'
                                 ) {
                                     if (in_array($id_start_ci, $class_keywords)) {
-                                        if (! $inside_structure && ! $id_start_ci === 'static') {
+                                        if (! $inside_structure && $id_start_ci !== 'static') {
                                             $isUsingScope = true;
                                         }
                                     } elseif (! (\PHP_MAJOR_VERSION >= 7 && in_array($id_start_ci, $builtin_types))) {


### PR DESCRIPTION
## Problem

Operator precedence bug — the `!` binds tighter than `===`:

```php
// Line 646: always evaluates to false
if (! $inside_structure && ! $id_start_ci === 'static') {
//                         ^^^^^^^^^^^^^^^^ → (bool) === 'static' → false
```

[`$isUsingScope`](https://github.com/laravel/serializable-closure/blob/92df8041c333e3feb9345184ed95e508a4ab00b0/src/Support/ReflectionClosure.php#L647) is never set to `true` via this path for non-static class keywords (`self`, `parent`).

## Solution

```php
if (! $inside_structure && $id_start_ci !== 'static') {
```

## Note

This bug is **masked at runtime** — the `$isUsingScope` flag is also set by other code paths ([line 558](https://github.com/laravel/serializable-closure/blob/92df8041c333e3feb9345184ed95e508a4ab00b0/src/Support/ReflectionClosure.php#L558) handles `self`/`static` in `new`/namespace contexts, and [line 593](https://github.com/laravel/serializable-closure/blob/92df8041c333e3feb9345184ed95e508a4ab00b0/src/Support/ReflectionClosure.php#L593) handles `self`/`parent` in non-`new` contexts). In practice, closures using `self` or `parent` already get `$isUsingScope = true` through those paths, so no observable behavior change is expected.

This means the fix cannot be verified by a test that distinguishes old vs. new behavior — it is a **code correctness improvement** that removes a dead/misleading branch.

PHPStan would flag the original code (`!$id_start_ci === 'static'`) but the file is [excluded from static analysis](https://github.com/laravel/serializable-closure/blob/92df8041c333e3feb9345184ed95e508a4ab00b0/phpstan.neon#L4) in this repo.

## Test plan

- [x] Existing test suite passes with no regressions