### PR TITLE
[2.x] [bug] Fix wrapClosures asymmetry with mapByReference

### DIFF
--- a/src/Serializers/Native.php
+++ b/src/Serializers/Native.php
@@ -253,6 +253,13 @@ class Native implements Serializable
             }
 
             $instance = $data;
+
+            if ($data instanceof DateTimeInterface) {
+                $storage[$instance] = $data;
+
+                return;
+            }
+
             $reflection = new ReflectionObject($instance);
 
             if (! $reflection->isUserDefined() || $reflection->hasMethod('__serialize')) {
@@ -273,7 +280,7 @@ class Native implements Serializable
                         continue;
                     }
 
-                    if (! $property->isInitialized($instance)) {
+                    if (! $property->isInitialized($instance) || ($property->isReadOnly() && $property->class !== $reflection->name)) {
                         continue;
                     }
 


### PR DESCRIPTION
## Summary

Adds `DateTimeInterface` exclusion to `wrapClosures()` to match `mapByReference()`.

## Problem

`mapByReference()` [returns early](https://github.com/laravel/serializable-closure/blob/92df8041c333e3feb9345184ed95e508a4ab00b0/src/Serializers/Native.php#L462-L466) for `DateTimeInterface` objects, but `wrapClosures()` does not. This causes unnecessary reflection, cloning via `newInstanceWithoutConstructor()`, and property traversal of DateTime objects during serialization.

## Solution

Added `DateTimeInterface` early return to `wrapClosures()` to match `mapByReference()`.

## Note

This PR also adds the inherited readonly property guard to `wrapClosures()`. However, #129 independently adds the same guard as part of its broader regression fix. If #129 merges first (expected), the readonly portion of this PR will be redundant. This PR will be rebased after #129 merges, at which point only the DateTime exclusion will remain as the unique contribution.

The inherited readonly crash was originally reported in [laravel/framework#51877](https://github.com/laravel/framework/issues/51877) and fixed in `mapPointers()` (#87) and `mapByReference()` (#96) but never in `wrapClosures()`.

## Test plan

- [x] Existing test suite passes with no regressions