### PR TITLE
[2.x] [bug] Fix instanceof with parenthesized expressions

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -23,6 +23,7 @@
             <file>tests/ReflectionClosureEmptyTokensTest.php</file>
             <file>tests/TypedClosurePropertyTest.php</file>
             <file>tests/SerializeNestedClosureRegressionTest.php</file>
+            <file>tests/InstanceofExpressionTest.php</file>
         </testsuite>
         <testsuite name="php81">
             <file phpVersion="8.1.0" phpVersionOperator=">=">tests/ReflectionClosurePhp80Test.php</file>

--- a/src/Support/ReflectionClosure.php
+++ b/src/Support/ReflectionClosure.php
@@ -521,6 +521,16 @@ class ReflectionClosure extends ReflectionFunction
                             $code .= $token[1];
                             $state = 'anonymous';
                             break;
+                        case '(':
+                            if ($context === 'instanceof') {
+                                $code .= '(';
+                                if ($isShortClosure) {
+                                    $open++;
+                                }
+                                $state = $lastState;
+                                break;
+                            }
+                            // no break
                         default:
                             $i--; //reprocess last
                             $state = 'id_name';

--- a/tests/InstanceofExpressionTest.php
+++ b/tests/InstanceofExpressionTest.php
@@ -1,0 +1,32 @@
+<?php
+
+use Foo\Bar as Baz;
+use Foo\Baz\Qux\Forest;
+
+test('instanceof with parenthesized class reference', function () {
+    $f1 = fn (Baz $a) => $this instanceof (Forest::class);
+    $e1 = 'fn (\Foo\Bar $a) => $this instanceof (\Foo\Baz\Qux\Forest::class)';
+
+    expect($f1)->toBeCode($e1);
+});
+
+test('instanceof with expression', function () {
+    $f1 = fn () => $this instanceof (class_exists('Foo') ? \Foo\Bar::class : \Foo\Baz\Qux\Forest::class);
+    $e1 = 'fn () => $this instanceof (\class_exists(\'Foo\') ? \Foo\Bar::class : \Foo\Baz\Qux\Forest::class)';
+
+    expect($f1)->toBeCode($e1);
+});
+
+test('instanceof without parentheses still works', function () {
+    $f1 = fn (Baz $a) => $this instanceof Forest;
+    $e1 = 'fn (\Foo\Bar $a) => $this instanceof \Foo\Baz\Qux\Forest';
+
+    expect($f1)->toBeCode($e1);
+});
+
+test('instanceof with variable still works', function () {
+    $f1 = fn ($class) => $this instanceof $class;
+    $e1 = 'fn ($class) => $this instanceof $class';
+
+    expect($f1)->toBeCode($e1);
+});


### PR DESCRIPTION
Relates to #104
Related to #78 / PR #80, which fixed `instanceof` breaking switch/case colons. This PR fixes `instanceof` with parenthesized expressions (`instanceof (Foo::class)`), which was not covered by that fix.

## Summary

PHP 8.0 added support for `instanceof` with parenthesized expressions (`instanceof (expression)`). The parser doesn't handle this, inserting a stale resolved class name before the opening parenthesis and producing invalid code.

## Root cause

In `ReflectionClosure::getCode()`, the `id_start` state doesn't handle `(` after `instanceof`. It falls through to the `default` case which reprocesses the token in `id_name` state with a stale `$id_start` from the previous name resolution (e.g. a type hint), causing that name to be output before the `(`.

## Fix

Added a `(` case to `id_start` that, when context is `instanceof`, outputs the `(` directly and returns to closure state without name resolution.

## What breaks without this fix

```php
use App\Models\User;
use App\Contracts\Authenticatable;

// Config-driven type checking - common in Laravel packages
// Found in: filament-team-management, laravel-authentication-log, mooxphp
$closure = fn (User $obj) => $obj instanceof (config('auth.model'));
// Before: fn (\App\Models\User $obj) => $obj instanceof \App\Models\User (config('auth.model'))
// Syntax error: stale type hint resolution inserted before (

// Multiple instanceof checks
$closure = fn (User $obj) => $obj instanceof (Authenticatable::class) || $obj instanceof (User::class);
// Before: fn (\App\Models\User $obj) => $obj instanceof \App\Models\User (\App\Contracts\Authenticatable::class) || ...
// Each instanceof gets the previous resolution's class name inserted
```

### Before / After

| Pattern | Before (broken) | After (fixed) |
|---------|-----------------|---------------|
| `$a instanceof (Forest::class)` | `$a instanceof \Foo\Bar (\Foo\Baz\Qux\Forest::class)` | `$a instanceof (\Foo\Baz\Qux\Forest::class)` |
| `$a instanceof (class_exists(...))` | `$a instanceof \Foo\Bar (\class_exists(...))` | `$a instanceof (\class_exists(...))` |
| `$a instanceof ($class)` | `$a instanceof string ($class)` | `$a instanceof ($class)` |
| Multiple instanceof | `$a instanceof \Foo\Bar (...) \|\| $a instanceof \Foo\Baz\Qux\Forest(...)` | Correct |

The fix works regardless of what precedes the `instanceof` expression. Verified against closures where the previously resolved token comes from type hints, `new` expressions, static references, previous `instanceof` checks, return types, and match conditions. All produce correct output.

30+ public repos on GitHub use `instanceof (expression)`, including [filament-team-management](https://github.com/stats4sd/filament-team-management), [laravel-authentication-log](https://github.com/johnnwanosike1/laravel-authentication-log), and [mooxphp](https://github.com/mooxphp/moox). The pattern works correctly in regular class methods - it only breaks when the code is inside a closure that goes through the serializable-closure parser. This is why the bug went unnoticed: packages use `instanceof (config(...))` in models and services where it works fine, but the same pattern in a queued closure crashes.

Verified before/after across unit tests, real-world pattern tests, Laravel integration tests, and edge cases. No regressions.

## Test plan

- [x] `instanceof` with parenthesized class reference
- [x] `instanceof` with ternary expression
- [x] Normal `instanceof` still works (regression check)
- [x] `instanceof` with variable still works (regression check)
- [x] Test registered in phpunit.xml.dist
- [x] All existing tests continue to pass

## Credit

Thanks to @ralphjsmit for identifying and reporting the bug with a failing test in #104.
