### PR TITLE
[2.x] [bug] Add true to builtin types list for PHP 8.2+

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -31,6 +31,9 @@
             <file phpVersion="8.1.0" phpVersionOperator=">=">tests/SerializerPhp81Test.php</file>
             <file phpVersion="8.1.0" phpVersionOperator=">=">tests/MethodOnlyAttributeTest.php</file>
         </testsuite>
+        <testsuite name="php82">
+            <file phpVersion="8.2.0" phpVersionOperator=">=">tests/TrueTypeTest.php</file>
+        </testsuite>
         <testsuite name="php84">
             <file phpVersion="8.4.0" phpVersionOperator=">=">tests/Php84Test.php</file>
         </testsuite>

--- a/src/Support/ReflectionClosure.php
+++ b/src/Support/ReflectionClosure.php
@@ -781,7 +781,7 @@ class ReflectionClosure extends ReflectionFunction
      */
     protected static function getBuiltinTypes()
     {
-        return ['array', 'callable', 'string', 'int', 'bool', 'float', 'iterable', 'void', 'object', 'mixed', 'false', 'null', 'never'];
+        return ['array', 'callable', 'string', 'int', 'bool', 'float', 'iterable', 'void', 'object', 'mixed', 'false', 'null', 'never', 'true'];
     }
 
     /**

--- a/tests/TrueTypeTest.php
+++ b/tests/TrueTypeTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Foo\Bar;
+
+use Laravel\SerializableClosure\Support\ReflectionClosure;
+
+// PHP 8.2+ added `true` as a standalone type (complement of `false`).
+// Without the fix, `true` gets treated as a class name and namespace-prefixed
+// when the closure is inside a namespace.
+
+test('true type hint is not namespace-prefixed', function () {
+    $f1 = fn (): true => true;
+    $e1 = 'fn (): true => true';
+
+    expect($f1)->toBeCode($e1);
+});
+
+test('true in union type is not namespace-prefixed', function () {
+    $f1 = fn (): string|true => true;
+    $e1 = 'fn (): string|true => true';
+
+    expect($f1)->toBeCode($e1);
+});
+
+test('true as parameter type is not namespace-prefixed', function () {
+    $f1 = fn (true $a) => $a;
+    $e1 = 'fn (true $a) => $a';
+
+    expect($f1)->toBeCode($e1);
+});

--- a/tests/TrueTypeTest.php
+++ b/tests/TrueTypeTest.php
@@ -2,8 +2,6 @@
 
 namespace Foo\Bar;
 
-use Laravel\SerializableClosure\Support\ReflectionClosure;
-
 // PHP 8.2+ added `true` as a standalone type (complement of `false`).
 // Without the fix, `true` gets treated as a class name and namespace-prefixed
 // when the closure is inside a namespace.


### PR DESCRIPTION
## Summary

PHP 8.2 added `true` as a standalone type (the complement of `false`). It was missing from `getBuiltinTypes()`, causing closures with `true` as a parameter type in namespaced code to have it namespace-prefixed, producing invalid code.

Low real-world impact since `true` as a parameter type is uncommon (most people use `bool`). Return types are not affected. This is a correctness fix to keep the builtin types list complete.

## Fix

One-line change: add `'true'` to the builtin types array in `getBuiltinTypes()`.

## What breaks without this fix

```php
// Before (broken) - in namespaced code:
fn (true $a) => $a;
// Serialized as: fn (\Foo\Bar\true $a) => $a
// Invalid PHP, crashes when the closure is deserialized.

// After (fixed):
fn (true $a) => $a;
// Serialized as: fn (true $a) => $a
```

Return types are not affected (they go through a different code path):

```php
// These already work without the fix:
fn (): true => true;           // Stays: fn (): true => true
fn (): string|true => true;    // Stays: fn (): string|true => true
```

Verified before/after by running the test against upstream 2.x (without fix) and this branch (with fix).

## Test plan

- [x] `true` parameter type not namespace-prefixed (the fix)
- [x] `true` return type still works (regression check)
- [x] `true` in union return type still works (regression check)
- [x] Test registered in phpunit.xml.dist under php82 suite (gated to PHP 8.2+)
- [x] All existing tests continue to pass