### PR TITLE
Fix nested closure serialization when returned from arrow function

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -24,6 +24,7 @@
             <file>tests/TypedClosurePropertyTest.php</file>
             <file>tests/SerializeNestedClosureRegressionTest.php</file>
             <file>tests/InstanceofExpressionTest.php</file>
+            <file>tests/NestedClosureFromArrowFunctionTest.php</file>
         </testsuite>
         <testsuite name="php81">
             <file phpVersion="8.1.0" phpVersionOperator=">=">tests/ReflectionClosurePhp80Test.php</file>

--- a/src/Support/ReflectionClosure.php
+++ b/src/Support/ReflectionClosure.php
@@ -761,6 +761,14 @@ class ReflectionClosure extends ReflectionFunction
         $lastItem = array_pop($candidates);
 
         if ($lastItem) {
+            if ($lastItem['isShortClosure']) {
+                $nested = $this->extractNestedClosure($lastItem);
+
+                if ($nested !== null && $this->verifyCandidateSignature($nested)) {
+                    $lastItem = $nested;
+                }
+            }
+
             $this->applyCandidate($lastItem);
             $code = $lastItem['code'];
         } else {
@@ -1452,5 +1460,79 @@ class ReflectionClosure extends ReflectionFunction
         }
 
         return true;
+    }
+
+    /**
+     * Extract a nested closure from a short closure candidate.
+     *
+     * When a closure like `fn() => static function() { ... }` is parsed,
+     * the token parser captures the outer arrow function. This method
+     * extracts the inner function/closure from the arrow function's body.
+     *
+     * @param  array  $candidate
+     * @return array|null
+     */
+    protected function extractNestedClosure($candidate)
+    {
+        if (! $candidate['isShortClosure']) {
+            return null;
+        }
+
+        $code = $candidate['code'];
+        $tokens = token_get_all('<?php '.$code);
+
+        // Find the code after the arrow function's =>
+        $afterArrow = false;
+        $nestedParts = [];
+
+        foreach ($tokens as $token) {
+            if (! $afterArrow) {
+                if (is_array($token) && $token[0] === T_DOUBLE_ARROW) {
+                    $afterArrow = true;
+                }
+
+                continue;
+            }
+
+            $nestedParts[] = is_array($token) ? $token[1] : $token;
+        }
+
+        $nestedCode = trim(implode('', $nestedParts));
+
+        if ($nestedCode === '') {
+            return null;
+        }
+
+        // Check if the nested code starts with a closure keyword
+        $trimmed = strtolower(ltrim($nestedCode));
+
+        if (substr($trimmed, 0, 8) !== 'function' && substr($trimmed, 0, 6) !== 'static') {
+            return null;
+        }
+
+        // Extract use variables from the nested closure's use clause
+        $use = [];
+        $nestedTokens = token_get_all('<?php '.$nestedCode);
+        $inUse = false;
+
+        foreach ($nestedTokens as $token) {
+            if (is_array($token)) {
+                if ($token[0] === T_USE) {
+                    $inUse = true;
+                } elseif ($token[0] === T_VARIABLE && $inUse) {
+                    $use[] = substr($token[1], 1);
+                }
+            } elseif ($token === '{') {
+                break;
+            }
+        }
+
+        return [
+            'code' => $nestedCode,
+            'use' => $use,
+            'isShortClosure' => false,
+            'isUsingThisObject' => false,
+            'isUsingScope' => $candidate['isUsingScope'],
+        ];
     }
 }

--- a/tests/NestedClosureFromArrowFunctionTest.php
+++ b/tests/NestedClosureFromArrowFunctionTest.php
@@ -1,0 +1,63 @@
+<?php
+
+use Laravel\SerializableClosure\Support\ReflectionClosure;
+
+test('static function returned from arrow function on same line is parsed correctly', function () {
+    $factory = fn () => static function () {
+        return 'inner';
+    };
+    $closure = $factory();
+
+    $reflection = new ReflectionClosure($closure);
+
+    expect($reflection->getCode())->toStartWith('static function ()');
+    expect($reflection->getCode())->not->toStartWith('fn');
+    expect($reflection->isShortClosure())->toBeFalse();
+});
+
+test('static function returned from arrow function serializes correctly', function () {
+    $factory = fn () => static function () {
+        return 'executed';
+    };
+    $closure = $factory();
+
+    $result = s($closure);
+
+    expect($result())->toBe('executed');
+})->with('serializers');
+
+test('function returned from arrow function on same line is parsed correctly', function () {
+    $factory = fn () => function () {
+        return 'inner';
+    };
+    $closure = $factory();
+
+    $reflection = new ReflectionClosure($closure);
+
+    expect($reflection->getCode())->toStartWith('function ()');
+    expect($reflection->getCode())->not->toStartWith('fn');
+    expect($reflection->isShortClosure())->toBeFalse();
+});
+
+test('static function with use clause returned from arrow function serializes correctly', function () {
+    $value = 'captured';
+    $factory = fn () => static function () use ($value) {
+        return $value;
+    };
+    $closure = $factory();
+
+    $result = s($closure);
+
+    expect($result())->toBe('captured');
+})->with('serializers');
+
+test('static function returned from arrow function with parameters serializes correctly', function () {
+    $factory = fn ($x) => static function () use ($x) {
+        return $x;
+    };
+    $closure = $factory('test');
+
+    $result = s($closure);
+
+    expect($result())->toBe('test');
+})->with('serializers');


### PR DESCRIPTION
## Summary

When a closure (e.g. `static function()`) is returned from an arrow function on the **same line**, the token parser incorrectly captures the outer arrow function instead of the inner closure:

```php
$factory = fn() => static function() { return 'executed'; };
$closure = $factory();

// ReflectionClosure::getCode() returns:
//   fn() => static function() { return 'executed'; }
// Expected:
//   static function() { return 'executed'; }
```

After deserialization, the closure becomes a **silent no-op** — it returns a `Closure` object instead of executing the intended logic, with no errors and no failed jobs.

## Root Cause

The inner closure is absorbed into the arrow function's body during parsing and never collected as a separate candidate. The candidate selection mechanism from #120 only handles **sibling** closures on the same line, not **nested** closures.

When there is only one candidate (the outer `fn`), `verifyCandidateSignature()` is either skipped (single candidate path) or passes (identical signatures), so the wrong code is used.

## Fix

- For short closure candidates, attempt to extract the nested function/closure from after the `=>` operator via a new `extractNestedClosure()` method
- Verify the extracted candidate against the reflected closure's signature using the existing `verifyCandidateSignature()`
- Only use the nested candidate if verification passes; otherwise fall back to existing behavior

## Affected Patterns

```php
fn() => static function() { ... }    // silent no-op after deserialization
fn() => function() { ... }           // silent no-op after deserialization
fn($x) => static function() use ($x) { ... }  // ArgumentCountError
```

## Tests

11 new tests in `tests/NestedClosureFromArrowFunctionTest.php` covering:
- `getCode()` returns the inner closure, not the wrapping `fn`
- Round-trip serialize/deserialize works for `static function` from `fn`
- Round-trip works for non-static `function` from `fn`
- `use` clause variables are preserved
- Arrow functions with parameters are handled correctly
- All three serializer backends (Native, Signed, Unsigned)

All 381 tests pass (370 existing + 11 new).