### PR TITLE
Register MultipleClosuresOnSameLineTest in phpunit.xml.dist

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -24,6 +24,7 @@
             <file>tests/TypedClosurePropertyTest.php</file>
             <file>tests/SerializeNestedClosureRegressionTest.php</file>
             <file>tests/InstanceofExpressionTest.php</file>
+            <file>tests/MultipleClosuresOnSameLineTest.php</file>
         </testsuite>
         <testsuite name="php81">
             <file phpVersion="8.1.0" phpVersionOperator=">=">tests/ReflectionClosurePhp80Test.php</file>


### PR DESCRIPTION
This adds `MultipleClosuresOnSameLineTest.php` to the `Tests` testsuite in `phpunit.xml.dist`.

Currently this test file exists in the repo but is not registered in the PHPUnit configuration, so its 6 tests are silently skipped during CI runs.

PR #134 was recently closed - it attempted to fix this by replacing all explicit `<file>` entries with directory-based discovery. This PR takes a simpler approach: just register the missing test file, consistent with the existing configuration style.

Fixes #132