### PR TITLE
[2.x] [bug] Bypass property hooks during serialization traversal on PHP 8.4+

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -38,6 +38,7 @@
         </testsuite>
         <testsuite name="php84">
             <file phpVersion="8.4.0" phpVersionOperator=">=">tests/Php84Test.php</file>
+            <file phpVersion="8.4.0" phpVersionOperator=">=">tests/PropertyHookTest.php</file>
         </testsuite>
     </testsuites>
 </phpunit>

--- a/src/Serializers/Native.php
+++ b/src/Serializers/Native.php
@@ -197,7 +197,8 @@ class Native implements Serializable
 
         if (! empty($this->code['objects'])) {
             foreach ($this->code['objects'] as $item) {
-                $item['property']->setValue(
+                static::setPropertyValue(
+                    $item['property'],
                     $item['instance'],
                     $item['object'] instanceof SerializableClosure || $item['object'] instanceof UnsignedSerializableClosure
                         ? $item['object']
@@ -282,10 +283,10 @@ class Native implements Serializable
                         continue;
                     }
 
-                    $value = $property->getValue($instance);
+                    $value = static::getPropertyValue($property, $instance);
 
                     if (static::isClosureTypedProperty($property)) {
-                        $property->setValue($data, $value);
+                        static::setPropertyValue($property, $data, $value);
 
                         continue;
                     }
@@ -294,7 +295,7 @@ class Native implements Serializable
                         static::wrapClosures($value, $storage);
                     }
 
-                    $property->setValue($data, $value);
+                    static::setPropertyValue($property, $data, $value);
                 }
             } while ($reflection = $reflection->getParentClass());
         }
@@ -386,7 +387,7 @@ class Native implements Serializable
                         continue;
                     }
 
-                    $item = $property->getValue($data);
+                    $item = static::getPropertyValue($property, $data);
 
                     if ($item instanceof SerializableClosure || $item instanceof UnsignedSerializableClosure || ($item instanceof SelfReference && $item->hash === $this->code['self'])) {
                         $this->code['objects'][] = [
@@ -396,7 +397,7 @@ class Native implements Serializable
                         ];
                     } elseif (is_array($item) || is_object($item)) {
                         $this->mapPointers($item);
-                        $property->setValue($data, $item);
+                        static::setPropertyValue($property, $data, $item);
                     }
                 }
             } while ($reflection = $reflection->getParentClass());
@@ -506,10 +507,10 @@ class Native implements Serializable
                         continue;
                     }
 
-                    $value = $property->getValue($instance);
+                    $value = static::getPropertyValue($property, $instance);
 
                     if (static::isClosureTypedProperty($property)) {
-                        $property->setValue($data, $value);
+                        static::setPropertyValue($property, $data, $value);
 
                         continue;
                     }
@@ -518,10 +519,39 @@ class Native implements Serializable
                         $this->mapByReference($value);
                     }
 
-                    $property->setValue($data, $value);
+                    static::setPropertyValue($property, $data, $value);
                 }
             } while ($reflection = $reflection->getParentClass());
         }
+    }
+
+    /**
+     * Get the value of a property, bypassing hooks on PHP 8.4+.
+     *
+     * @param  \ReflectionProperty  $property
+     * @param  object  $object
+     * @return mixed
+     */
+    protected static function getPropertyValue(ReflectionProperty $property, object $object): mixed
+    {
+        return PHP_VERSION_ID >= 80400
+            ? $property->getRawValue($object)
+            : $property->getValue($object);
+    }
+
+    /**
+     * Set the value of a property, bypassing hooks on PHP 8.4+.
+     *
+     * @param  \ReflectionProperty  $property
+     * @param  object  $object
+     * @param  mixed  $value
+     * @return void
+     */
+    protected static function setPropertyValue(ReflectionProperty $property, object $object, mixed $value): void
+    {
+        PHP_VERSION_ID >= 80400
+            ? $property->setRawValue($object, $value)
+            : $property->setValue($object, $value);
     }
 
     /**

--- a/tests/PropertyHookTest.php
+++ b/tests/PropertyHookTest.php
@@ -1,0 +1,195 @@
+<?php
+
+it('does not trigger set hook during serialization', function () {
+    $order = new OrderWithSetHook();
+    $order->price = 50.00;
+
+    // Reset the counter after initial set
+    OrderWithSetHook::$setHookCallCount = 0;
+
+    $closure = function () use ($order) {
+        return $order->price;
+    };
+
+    $serialized = s($closure);
+
+    expect(OrderWithSetHook::$setHookCallCount)->toBe(0)
+        ->and($serialized())->toBe(50.00);
+})->with('serializers');
+
+it('does not trigger get hook during serialization', function () {
+    $product = new ProductWithGetHook('Widget', 25.00);
+
+    // Reset the counter after construction
+    ProductWithGetHook::$getHookCallCount = 0;
+
+    $closure = function () use ($product) {
+        return $product->name;
+    };
+
+    $serialized = s($closure);
+
+    expect(ProductWithGetHook::$getHookCallCount)->toBe(0);
+
+    // After unserialization, accessing the property SHOULD trigger the hook
+    $result = $serialized();
+    expect($result)->toBe('Widget');
+})->with('serializers');
+
+it('does not trigger hooks on object with both get and set hooks', function () {
+    $item = new ItemWithBothHooks();
+    $item->label = 'test-item';
+
+    ItemWithBothHooks::$getHookCallCount = 0;
+    ItemWithBothHooks::$setHookCallCount = 0;
+
+    $closure = function () use ($item) {
+        return $item->label;
+    };
+
+    $serialized = s($closure);
+
+    expect(ItemWithBothHooks::$getHookCallCount)->toBe(0)
+        ->and(ItemWithBothHooks::$setHookCallCount)->toBe(0);
+
+    $result = $serialized();
+    expect($result)->toBe('test-item');
+})->with('serializers');
+
+it('still serializes objects without hooks correctly', function () {
+    $obj = new PlainObjectNoHooks();
+    $obj->name = 'plain';
+    $obj->value = 42;
+
+    $closure = function () use ($obj) {
+        return [$obj->name, $obj->value];
+    };
+
+    $serialized = s($closure);
+
+    expect($serialized())->toBe(['plain', 42]);
+})->with('serializers');
+
+it('does not trigger side effects during serialization of hooked property', function () {
+    SideEffectTracker::$log = [];
+
+    $tracker = new ObjectWithSideEffectHook();
+    $tracker->status = 'active';
+
+    // Clear the log from the initial set
+    SideEffectTracker::$log = [];
+
+    $closure = function () use ($tracker) {
+        return $tracker->status;
+    };
+
+    $serialized = s($closure);
+
+    expect(SideEffectTracker::$log)->toBe([])
+        ->and($serialized())->toBe('active');
+})->with('serializers');
+
+it('handles bound closure with hooked properties', function () {
+    $binding = new BoundClosureWithHooks();
+
+    $f = $binding->getClosure();
+
+    OrderWithSetHook::$setHookCallCount = 0;
+
+    $serialized = s($f);
+
+    expect(OrderWithSetHook::$setHookCallCount)->toBe(0);
+
+    $result = $serialized();
+    expect($result)->toBe(99.99);
+})->with('serializers');
+
+// --- Test fixture classes ---
+
+class OrderWithSetHook
+{
+    public static int $setHookCallCount = 0;
+
+    public float $price {
+        set(float $value) {
+            static::$setHookCallCount++;
+            $this->price = $value;
+        }
+    }
+}
+
+class ProductWithGetHook
+{
+    public static int $getHookCallCount = 0;
+
+    public string $name {
+        get {
+            static::$getHookCallCount++;
+            return $this->name;
+        }
+    }
+
+    public float $price;
+
+    public function __construct(string $name, float $price)
+    {
+        $this->name = $name;
+        $this->price = $price;
+    }
+}
+
+class ItemWithBothHooks
+{
+    public static int $getHookCallCount = 0;
+    public static int $setHookCallCount = 0;
+
+    public string $label {
+        get {
+            static::$getHookCallCount++;
+            return $this->label;
+        }
+        set(string $value) {
+            static::$setHookCallCount++;
+            $this->label = $value;
+        }
+    }
+}
+
+class PlainObjectNoHooks
+{
+    public string $name;
+    public int $value;
+}
+
+class SideEffectTracker
+{
+    public static array $log = [];
+}
+
+class ObjectWithSideEffectHook
+{
+    public string $status {
+        set(string $value) {
+            SideEffectTracker::$log[] = "status set to: $value";
+            $this->status = $value;
+        }
+    }
+}
+
+class BoundClosureWithHooks
+{
+    private OrderWithSetHook $order;
+
+    public function __construct()
+    {
+        $this->order = new OrderWithSetHook();
+        $this->order->price = 99.99;
+    }
+
+    public function getClosure(): Closure
+    {
+        return function () {
+            return $this->order->price;
+        };
+    }
+}

--- a/tests/PropertyHookTest.php
+++ b/tests/PropertyHookTest.php
@@ -125,6 +125,7 @@ class ProductWithGetHook
     public string $name {
         get {
             static::$getHookCallCount++;
+
             return $this->name;
         }
     }
@@ -146,6 +147,7 @@ class ItemWithBothHooks
     public string $label {
         get {
             static::$getHookCallCount++;
+
             return $this->label;
         }
         set(string $value) {


### PR DESCRIPTION
Fixes #144

## Summary

On PHP 8.4+, `ReflectionProperty::setValue()` and `getValue()` trigger [property hooks](https://wiki.php.net/rfc/property-hooks). During serialization traversal in `Native::wrapClosures()` and `Native::mapByReference()`, this causes unintended side effects when objects captured in closures have hooked properties.

**Before (bug):**

```php
class Order {
    public float $price {
        set(float $value) {
            Log::info("Price set to $value"); // fires during serialization!
            $this->price = $value;
        }
    }
}

$order = new Order();
$order->price = 50.0;

$closure = function() use ($order) { return $order->price; };
serialize(new SerializableClosure($closure));
// Set hook fires unexpectedly during serialization traversal
```

**After (fix):**

```php
serialize(new SerializableClosure($closure));
// No hooks fire. Backing storage accessed directly via getRawValue()/setRawValue().
```

## Root cause

`Native::wrapClosures()`, `Native::mapPointers()`, and `Native::mapByReference()` traverse captured objects using `ReflectionProperty::getValue()` and `setValue()`. On PHP 8.4+, these methods invoke property hooks instead of accessing backing storage directly.

## Fix

Added `getPropertyValue()` and `setPropertyValue()` helper methods that use `getRawValue()`/`setRawValue()` on PHP 8.4+ (bypassing hooks) and fall back to `getValue()`/`setValue()` on earlier PHP versions (where hooks don't exist).

9 call sites updated across `wrapClosures()` (3), `mapPointers()` (2), `mapByReference()` (3), and `__unserialize()` (1).

## Upstream precedent

[opis/closure 4.3.0](https://github.com/opis/closure/releases/tag/4.3.0) made the same property hooks change, switching to `getRawValue()`/`setRawValue()` and `get_mangled_object_vars()`.

## Impact

As PHP 8.4 property hook adoption grows, any closure capturing an object with hooked properties would have those hooks fire during serialization. This can cause:
- Side effects (logging, event dispatching, validation)
- State corruption (computed/derived properties recalculated)
- Exceptions (validation hooks throwing on re-assignment)

**Real-world adoption:**
- [AzuraCast](https://github.com/AzuraCast/AzuraCast) (15k+ stars) already uses property hooks on Doctrine entities: `public string $path { set => $this->truncateString($value, 500); }`. Any entity serialized through queues/cache would trigger hooks.
- [bootgly](https://github.com/bootgly/bootgly) uses property hooks on CLI command objects.
- [shlinkio/shlink](https://github.com/shlinkio/shlink) is explicitly planning property hook adoption on entities.

Current adopters like AzuraCast happen to use idempotent hooks (e.g., `truncateString()`) where re-triggering produces the same result. But this is luck, not design. A non-idempotent hook (audit logging, event dispatching, counter incrementing) would produce phantom side effects during serialization with no indication anything is wrong.

## Testing

**In the PR:** 6 test cases (18 with serializer datasets) covering set hooks, get hooks, both hooks, plain objects (regression), side-effect hooks, and bound closures with hooked properties.

**Independent testing:** [JoshSalway/sc-146-tests](https://github.com/JoshSalway/sc-146-tests) with comprehensive + sanity suites.

## Test plan

- [x] Set hook not triggered during serialization
- [x] Get hook not triggered during serialization
- [x] Both hooks not triggered during serialization
- [x] Computed/virtual properties not triggered
- [x] Validation hooks don't throw during serialization
- [x] Multiple hooked objects in same closure
- [x] Mixed hooked and non-hooked properties
- [x] Nested objects with hooks
- [x] Bulk serialization (50x) - hook count unchanged
- [x] Objects without hooks still work (regression guard)
- [x] All existing tests pass
- [x] CI green across PHP 8.1-8.5, Laravel 10-13
- [x] StyleCI passed