### PR TITLE
[2.x] [support] Handle closures in constant expressions (PHP 8.5)

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -39,5 +39,8 @@
         <testsuite name="php84">
             <file phpVersion="8.4.0" phpVersionOperator=">=">tests/Php84Test.php</file>
         </testsuite>
+        <testsuite name="php85">
+            <file phpVersion="8.5.0" phpVersionOperator=">=">tests/Php85Test.php</file>
+        </testsuite>
     </testsuites>
 </phpunit>

--- a/src/Support/ReflectionClosure.php
+++ b/src/Support/ReflectionClosure.php
@@ -220,6 +220,11 @@ class ReflectionClosure extends ReflectionFunction
                             $state = 'closure';
                             $open++;
                             break;
+                        case T_FN:
+                        case T_FUNCTION:
+                            $code .= $token[1];
+                            $i = $this->skipNestedClosure($tokens, $i, $l, $code, $token[0] === T_FN);
+                            break;
                         default:
                             $code .= is_array($token) ? $token[1] : $token;
                     }
@@ -1321,6 +1326,78 @@ class ReflectionClosure extends ReflectionFunction
         $id_name = '\\'.implode('\\', $pieces);
 
         return [$id_start, $id_start_ci, $id_name];
+    }
+
+    /**
+     * Skip over a nested closure in parameter default values.
+     *
+     * When the parser encounters T_FUNCTION or T_FN inside closure_args (parameter defaults),
+     * this method consumes all tokens belonging to the nested closure and appends them to $code.
+     *
+     * @param  array  $tokens
+     * @param  int  $i  Current token index (pointing to the T_FUNCTION/T_FN token)
+     * @param  int  $l  Total token count
+     * @param  string  $code  Code string to append to (passed by reference)
+     * @param  bool  $isArrowFunction  Whether this is a T_FN (arrow function)
+     * @return int  The new token index after the nested closure
+     */
+    protected function skipNestedClosure(array $tokens, int $i, int $l, string &$code, bool $isArrowFunction): int
+    {
+        $depth = 0;
+        $bodyStarted = false;
+
+        for ($i++; $i < $l; $i++) {
+            $token = $tokens[$i];
+            $code .= is_array($token) ? $token[1] : $token;
+
+            if ($isArrowFunction) {
+                // For arrow functions: fn(...) => expr
+                // Track parens for the parameter list, then after =>, track the expression
+                // The expression ends at a , or ) at depth 0
+                if ($token[0] === '(' || $token[0] === '{' || $token[0] === '[') {
+                    $depth++;
+                } elseif ($token[0] === ')' || $token[0] === '}' || $token[0] === ']') {
+                    $depth--;
+                    if ($depth < 0) {
+                        // We've consumed a ) that belongs to the outer param list, put it back
+                        $code = substr($code, 0, -1);
+                        $i--;
+                        break;
+                    }
+                } elseif ($token[0] === T_DOUBLE_ARROW && $depth === 0) {
+                    $bodyStarted = true;
+                } elseif ($token[0] === ',' && $depth === 0 && $bodyStarted) {
+                    // Comma at depth 0 after => ends the arrow function expression
+                    // Put the comma back for the outer parser
+                    $code = substr($code, 0, -1);
+                    $i--;
+                    break;
+                } elseif ($token[0] === T_FN || $token[0] === T_FUNCTION) {
+                    // Nested closure inside the arrow function expression
+                    $i = $this->skipNestedClosure($tokens, $i, $l, $code, $token[0] === T_FN);
+                }
+            } else {
+                // For regular functions: function (...) { ... }
+                // First track parens for parameter list, then track braces for the body
+                if ($token[0] === '(' || $token[0] === '{') {
+                    $depth++;
+                    if ($token[0] === '{') {
+                        $bodyStarted = true;
+                    }
+                } elseif ($token[0] === ')' || $token[0] === '}') {
+                    $depth--;
+                    if ($depth === 0 && $bodyStarted) {
+                        // Closing brace of the function body - nested closure is complete
+                        break;
+                    }
+                } elseif ($token[0] === T_FN || $token[0] === T_FUNCTION) {
+                    // Nested closure inside the function body
+                    $i = $this->skipNestedClosure($tokens, $i, $l, $code, $token[0] === T_FN);
+                }
+            }
+        }
+
+        return $i;
     }
 
     /**

--- a/src/Support/ReflectionClosure.php
+++ b/src/Support/ReflectionClosure.php
@@ -1339,7 +1339,7 @@ class ReflectionClosure extends ReflectionFunction
      * @param  int  $l  Total token count
      * @param  string  $code  Code string to append to (passed by reference)
      * @param  bool  $isArrowFunction  Whether this is a T_FN (arrow function)
-     * @return int  The new token index after the nested closure
+     * @return int The new token index after the nested closure
      */
     protected function skipNestedClosure(array $tokens, int $i, int $l, string &$code, bool $isArrowFunction): int
     {

--- a/tests/Php85Test.php
+++ b/tests/Php85Test.php
@@ -1,18 +1,24 @@
 <?php
 
 test('closure with static function as default parameter value', function () {
-    $f = function (callable $handler = static function () { return 'fallback'; }) {
+    $f = function (callable $handler = static function () {
+        return 'fallback';
+    }) {
         return $handler();
     };
 
     $s = s($f);
 
     expect($s())->toBe('fallback')
-        ->and($s(function () { return 'custom'; }))->toBe('custom');
+        ->and($s(function () {
+            return 'custom';
+        }))->toBe('custom');
 })->with('serializers');
 
 test('static fn with static function as default parameter value', function () {
-    $f = static fn(callable $handler = static function () { return 'fn-fallback'; }) => $handler();
+    $f = static fn (callable $handler = static function () {
+        return 'fn-fallback';
+    }) => $handler();
 
     $s = s($f);
 
@@ -20,8 +26,12 @@ test('static fn with static function as default parameter value', function () {
 })->with('serializers');
 
 test('closure with multiple static function defaults', function () {
-    $f = function (callable $a = static function () { return 'A'; }, callable $b = static function () { return 'B'; }) {
-        return $a() . $b();
+    $f = function (callable $a = static function () {
+        return 'A';
+    }, callable $b = static function () {
+        return 'B';
+    }) {
+        return $a().$b();
     };
 
     $s = s($f);
@@ -30,7 +40,9 @@ test('closure with multiple static function defaults', function () {
 })->with('serializers');
 
 test('closure with static function default that has return type', function () {
-    $f = function (callable $handler = static function (): int { return 42; }) {
+    $f = function (callable $handler = static function (): int {
+        return 42;
+    }) {
         return $handler();
     };
 
@@ -40,7 +52,9 @@ test('closure with static function default that has return type', function () {
 })->with('serializers');
 
 test('closure with static function default that has parameters', function () {
-    $f = function (callable $handler = static function (int $x = 5): int { return $x * 2; }) {
+    $f = function (callable $handler = static function (int $x = 5): int {
+        return $x * 2;
+    }) {
         return $handler();
     };
 
@@ -50,7 +64,11 @@ test('closure with static function default that has parameters', function () {
 })->with('serializers');
 
 test('closure with nested static function in default', function () {
-    $f = function (callable $handler = static function () { return static function () { return 99; }; }) {
+    $f = function (callable $handler = static function () {
+        return static function () {
+            return 99;
+        };
+    }) {
         return $handler()();
     };
 
@@ -60,8 +78,10 @@ test('closure with nested static function in default', function () {
 })->with('serializers');
 
 test('closure with mixed regular and static function defaults', function () {
-    $f = function (int $x = 10, callable $handler = static function () { return 'default'; }, string $y = 'test') {
-        return $x . $handler() . $y;
+    $f = function (int $x = 10, callable $handler = static function () {
+        return 'default';
+    }, string $y = 'test') {
+        return $x.$handler().$y;
     };
 
     $s = s($f);

--- a/tests/Php85Test.php
+++ b/tests/Php85Test.php
@@ -1,0 +1,70 @@
+<?php
+
+test('closure with static function as default parameter value', function () {
+    $f = function (callable $handler = static function () { return 'fallback'; }) {
+        return $handler();
+    };
+
+    $s = s($f);
+
+    expect($s())->toBe('fallback')
+        ->and($s(function () { return 'custom'; }))->toBe('custom');
+})->with('serializers');
+
+test('static fn with static function as default parameter value', function () {
+    $f = static fn(callable $handler = static function () { return 'fn-fallback'; }) => $handler();
+
+    $s = s($f);
+
+    expect($s())->toBe('fn-fallback');
+})->with('serializers');
+
+test('closure with multiple static function defaults', function () {
+    $f = function (callable $a = static function () { return 'A'; }, callable $b = static function () { return 'B'; }) {
+        return $a() . $b();
+    };
+
+    $s = s($f);
+
+    expect($s())->toBe('AB');
+})->with('serializers');
+
+test('closure with static function default that has return type', function () {
+    $f = function (callable $handler = static function (): int { return 42; }) {
+        return $handler();
+    };
+
+    $s = s($f);
+
+    expect($s())->toBe(42);
+})->with('serializers');
+
+test('closure with static function default that has parameters', function () {
+    $f = function (callable $handler = static function (int $x = 5): int { return $x * 2; }) {
+        return $handler();
+    };
+
+    $s = s($f);
+
+    expect($s())->toBe(10);
+})->with('serializers');
+
+test('closure with nested static function in default', function () {
+    $f = function (callable $handler = static function () { return static function () { return 99; }; }) {
+        return $handler()();
+    };
+
+    $s = s($f);
+
+    expect($s())->toBe(99);
+})->with('serializers');
+
+test('closure with mixed regular and static function defaults', function () {
+    $f = function (int $x = 10, callable $handler = static function () { return 'default'; }, string $y = 'test') {
+        return $x . $handler() . $y;
+    };
+
+    $s = s($f);
+
+    expect($s())->toBe('10defaulttest');
+})->with('serializers');


### PR DESCRIPTION
Fixes #145

> **Status:** This PR will remain as draft until PHP 8.5 RC is released. The feature and tests are complete and CI-green, but PHP 8.5 is not yet released.

## Summary

PHP 8.5 (unreleased) allows [closures in constant expressions](https://wiki.php.net/rfc/closures_in_const_expr), meaning `static function() {}` closures can appear as default parameter values. The `ReflectionClosure` parser does not handle `T_FUNCTION`/`T_FN` tokens in the `closure_args` state, causing incorrect code extraction.

## The bug

```php
$closure = function (callable $handler = static function () { return 'fallback'; }) {
    return $handler();
};
// Parser confuses inner function's braces with outer closure body
// Got:      function (callable $handler = static function () { return 'fallback'; }
// Expected: function (callable $handler = static function () { return 'fallback'; }) { return $handler(); }
```

With multiple closure defaults, the parser would pick up the wrong closure entirely.

## Fix

Added a `skipNestedClosure()` method that consumes all tokens belonging to a nested closure when `T_FUNCTION` or `T_FN` is encountered inside the `closure_args` state. It handles:
- Regular functions: tracks `()` for params and `{}` for body
- Arrow functions: tracks `()` for params, then the expression after `=>`
- Nested closures within nested closures (recursive)

## Test plan

- [x] Static function as default parameter value
- [x] Static fn (arrow function outer) with static function default
- [x] Multiple static function defaults
- [x] Static function default with return type
- [x] Static function default with parameters
- [x] Nested static function in default
- [x] Mixed regular and closure defaults (regression guard)
- [x] All existing tests pass
- [x] PHPStan clean
- [x] CI green

> Note: PHP 8.5 only supports `static function() {}` in constant expressions, not `static fn()`. The `T_FN` handling is included for forward-compatibility.