### PR TITLE
[2.x] Fix nested closure returned from arrow function

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -25,6 +25,7 @@
             <file>tests/SerializeNestedClosureRegressionTest.php</file>
             <file>tests/InstanceofExpressionTest.php</file>
             <file>tests/MultipleClosuresOnSameLineTest.php</file>
+            <file>tests/NestedClosureFromArrowFunctionTest.php</file>
         </testsuite>
         <testsuite name="php81">
             <file phpVersion="8.1.0" phpVersionOperator=">=">tests/ReflectionClosurePhp80Test.php</file>

--- a/src/Support/ReflectionClosure.php
+++ b/src/Support/ReflectionClosure.php
@@ -761,7 +761,7 @@ class ReflectionClosure extends ReflectionFunction
         $lastItem = array_pop($candidates);
 
         if ($lastItem) {
-            if ($lastItem['isShortClosure'] && ($nested = $this->extractNestedClosure($lastItem)) !== null) {
+            if ($lastItem['isShortClosure'] && $this->isNestedClosure() && ($nested = $this->extractNestedClosure($lastItem)) !== null) {
                 $lastItem = $nested;
             }
 
@@ -1459,8 +1459,21 @@ class ReflectionClosure extends ReflectionFunction
     }
 
     /**
-     * Extract a nested closure from a short closure's body when the arrow
-     * function wraps a regular closure, e.g. `fn() => static function() { ... }`.
+     * Determine if this closure is nested inside another closure.
+     *
+     * @return bool
+     */
+    protected function isNestedClosure()
+    {
+        if (PHP_VERSION_ID < 80400) {
+            return true;
+        }
+
+        return str_contains(parent::getName(), '{closure:{closure:');
+    }
+
+    /**
+     * Extract the inner closure from a short closure candidate.
      *
      * @param  array  $candidate
      * @return array|null
@@ -1499,7 +1512,6 @@ class ReflectionClosure extends ReflectionFunction
         }
         $innerCode = trim($innerCode);
 
-        // Determine if the inner closure is a short closure (fn or static fn)
         $isInnerShort = $tokens[$innerStart][0] === T_FN;
         if (! $isInnerShort && $tokens[$innerStart][0] === T_STATIC) {
             foreach (array_slice($tokens, $innerStart + 1) as $t) {
@@ -1513,7 +1525,6 @@ class ReflectionClosure extends ReflectionFunction
             }
         }
 
-        // Extract use variables from the inner closure's use clause
         $use = [];
         if (! $isInnerShort) {
             $innerTokens = token_get_all('<?php '.$innerCode);

--- a/src/Support/ReflectionClosure.php
+++ b/src/Support/ReflectionClosure.php
@@ -761,6 +761,10 @@ class ReflectionClosure extends ReflectionFunction
         $lastItem = array_pop($candidates);
 
         if ($lastItem) {
+            if ($lastItem['isShortClosure'] && ($nested = $this->extractNestedClosure($lastItem)) !== null) {
+                $lastItem = $nested;
+            }
+
             $this->applyCandidate($lastItem);
             $code = $lastItem['code'];
         } else {
@@ -1452,5 +1456,87 @@ class ReflectionClosure extends ReflectionFunction
         }
 
         return true;
+    }
+
+    /**
+     * Extract a nested closure from a short closure's body when the arrow
+     * function wraps a regular closure, e.g. `fn() => static function() { ... }`.
+     *
+     * @param  array  $candidate
+     * @return array|null
+     */
+    protected function extractNestedClosure($candidate)
+    {
+        $tokens = token_get_all('<?php '.$candidate['code']);
+        $afterArrow = false;
+        $innerStart = null;
+
+        foreach ($tokens as $i => $token) {
+            if (! $afterArrow) {
+                if (is_array($token) && $token[0] === T_DOUBLE_ARROW) {
+                    $afterArrow = true;
+                }
+                continue;
+            }
+
+            if (is_array($token) && in_array($token[0], [T_FUNCTION, T_STATIC, T_FN], true)) {
+                $innerStart = $i;
+                break;
+            }
+
+            if (! is_array($token) || ! in_array($token[0], [T_WHITESPACE, T_COMMENT], true)) {
+                return null;
+            }
+        }
+
+        if ($innerStart === null) {
+            return null;
+        }
+
+        $innerCode = '';
+        for ($i = $innerStart; $i < count($tokens); $i++) {
+            $innerCode .= is_array($tokens[$i]) ? $tokens[$i][1] : $tokens[$i];
+        }
+        $innerCode = trim($innerCode);
+
+        // Determine if the inner closure is a short closure (fn or static fn)
+        $isInnerShort = $tokens[$innerStart][0] === T_FN;
+        if (! $isInnerShort && $tokens[$innerStart][0] === T_STATIC) {
+            foreach (array_slice($tokens, $innerStart + 1) as $t) {
+                if (is_array($t) && $t[0] === T_FN) {
+                    $isInnerShort = true;
+                    break;
+                }
+                if (! is_array($t) || $t[0] !== T_WHITESPACE) {
+                    break;
+                }
+            }
+        }
+
+        // Extract use variables from the inner closure's use clause
+        $use = [];
+        if (! $isInnerShort) {
+            $innerTokens = token_get_all('<?php '.$innerCode);
+            $inUse = false;
+            foreach ($innerTokens as $token) {
+                if (is_array($token) && $token[0] === T_USE) {
+                    $inUse = true;
+                } elseif ($inUse && is_array($token) && $token[0] === T_VARIABLE) {
+                    $use[] = substr($token[1], 1);
+                } elseif ($inUse && $token === '{') {
+                    break;
+                }
+            }
+        }
+
+        $nested = [
+            'code' => $innerCode,
+            'use' => $use,
+            'isShortClosure' => $isInnerShort,
+            'isUsingThisObject' => $candidate['isUsingThisObject'],
+            'isUsingScope' => $candidate['isUsingScope'],
+        ];
+
+        return $this->verifyCandidateSignature($nested) ? $nested : null;
     }
 }

--- a/src/Support/ReflectionClosure.php
+++ b/src/Support/ReflectionClosure.php
@@ -1548,6 +1548,17 @@ class ReflectionClosure extends ReflectionFunction
             'isUsingScope' => $candidate['isUsingScope'],
         ];
 
+        // If the extracted closure is still a short closure, it may contain
+        // another nested closure (e.g. fn() => fn() => function() {}). Recurse
+        // to peel through all arrow function layers before verifying.
+        if ($isInnerShort) {
+            $deeper = $this->extractNestedClosure($nested);
+
+            if ($deeper !== null) {
+                return $deeper;
+            }
+        }
+
         return $this->verifyCandidateSignature($nested) ? $nested : null;
     }
 }

--- a/tests/NestedClosureFromArrowFunctionTest.php
+++ b/tests/NestedClosureFromArrowFunctionTest.php
@@ -1,0 +1,87 @@
+<?php
+
+use Laravel\SerializableClosure\Support\ReflectionClosure;
+
+test('static function returned from arrow function is parsed correctly', function () {
+    $factory = fn () => static function () {
+        return 'inner';
+    };
+    $closure = $factory();
+
+    $reflection = new ReflectionClosure($closure);
+
+    expect($reflection->getCode())->toStartWith('static function ()');
+    expect($reflection->getCode())->not->toStartWith('fn');
+    expect($reflection->isShortClosure())->toBeFalse();
+});
+
+test('static function returned from arrow function serializes correctly', function () {
+    $factory = fn () => static function () {
+        return 'executed';
+    };
+    $closure = $factory();
+
+    expect(s($closure)())->toBe('executed');
+})->with('serializers');
+
+test('function returned from arrow function is parsed correctly', function () {
+    $factory = fn () => function () {
+        return 'inner';
+    };
+    $closure = $factory();
+
+    $reflection = new ReflectionClosure($closure);
+
+    expect($reflection->getCode())->toStartWith('function ()');
+    expect($reflection->getCode())->not->toStartWith('fn');
+    expect($reflection->isShortClosure())->toBeFalse();
+});
+
+test('function returned from arrow function serializes correctly', function () {
+    $factory = fn () => function () {
+        return 'hello';
+    };
+    $closure = $factory();
+
+    expect(s($closure)())->toBe('hello');
+})->with('serializers');
+
+test('arrow function returned from arrow function serializes correctly', function () {
+    $factory = fn () => fn () => 'inner';
+    $closure = $factory();
+
+    expect(s($closure)())->toBe('inner');
+})->with('serializers');
+
+test('function with use clause returned from arrow function serializes correctly', function () {
+    $value = 'captured';
+    $factory = fn () => static function () use ($value) {
+        return $value;
+    };
+    $closure = $factory();
+
+    expect(s($closure)())->toBe('captured');
+})->with('serializers');
+
+test('function returned from arrow function with parameters serializes correctly', function () {
+    $factory = fn ($x) => static function () use ($x) {
+        return $x;
+    };
+    $closure = $factory('test');
+
+    expect(s($closure)())->toBe('test');
+})->with('serializers');
+
+test('standalone arrow function still works', function () {
+    $fn = fn () => 42;
+
+    expect(s($fn)())->toBe(42);
+})->with('serializers');
+
+test('standalone function still works', function () {
+    $fn = function () {
+        return 42;
+    };
+
+    expect(s($fn)())->toBe(42);
+})->with('serializers');

--- a/tests/NestedClosureFromArrowFunctionTest.php
+++ b/tests/NestedClosureFromArrowFunctionTest.php
@@ -106,3 +106,53 @@ test('function with return type returned from arrow function serializes correctl
 
     expect(s($closure)())->toBe('typed');
 })->with('serializers');
+
+// Deep nesting tests (3+ levels)
+
+test('static function returned from 3-level arrow function nesting is parsed correctly', function () {
+    $factory = fn () => fn () => static function () {
+        return 'deep';
+    };
+    $closure = $factory()();
+
+    $reflection = new ReflectionClosure($closure);
+
+    expect($reflection->getCode())->toStartWith('static function ()');
+    expect($reflection->getCode())->not->toStartWith('fn');
+    expect($reflection->isShortClosure())->toBeFalse();
+});
+
+test('static function returned from 3-level arrow function nesting serializes correctly', function () {
+    $factory = fn () => fn () => static function () {
+        return '3-level';
+    };
+    $closure = $factory()();
+
+    expect(s($closure)())->toBe('3-level');
+})->with('serializers');
+
+test('arrow function returned from 3-level arrow function nesting serializes correctly', function () {
+    $factory = fn () => fn () => fn () => '3-arrow';
+    $closure = $factory()();
+
+    expect(s($closure)())->toBe('3-arrow');
+})->with('serializers');
+
+test('static function returned from 4-level arrow function nesting serializes correctly', function () {
+    $factory = fn () => fn () => fn () => static function () {
+        return '4-level';
+    };
+    $closure = $factory()()();
+
+    expect(s($closure)())->toBe('4-level');
+})->with('serializers');
+
+test('function with use clause returned from 3-level arrow function nesting serializes correctly', function () {
+    $value = 'captured-deep';
+    $factory = fn () => fn () => static function () use ($value) {
+        return $value;
+    };
+    $closure = $factory()();
+
+    expect(s($closure)())->toBe('captured-deep');
+})->with('serializers');

--- a/tests/NestedClosureFromArrowFunctionTest.php
+++ b/tests/NestedClosureFromArrowFunctionTest.php
@@ -85,3 +85,24 @@ test('standalone function still works', function () {
 
     expect(s($fn)())->toBe(42);
 })->with('serializers');
+
+test('factory arrow function itself serializes correctly', function () {
+    $factory = fn () => static function () {
+        return 'inner';
+    };
+
+    $restored = s($factory);
+    $inner = $restored();
+
+    expect($inner)->toBeInstanceOf(Closure::class);
+    expect($inner())->toBe('inner');
+})->with('serializers');
+
+test('function with return type returned from arrow function serializes correctly', function () {
+    $factory = fn () => static function (): string {
+        return 'typed';
+    };
+    $closure = $factory();
+
+    expect(s($closure)())->toBe('typed');
+})->with('serializers');


### PR DESCRIPTION
Fixes #148, fixes #152

## Summary

When a closure is returned from an arrow function on the same line, `ReflectionClosure::getCode()` misidentifies the inner closure as the outer arrow function. After serialization, the inner closure becomes a silent no-op. This handles both 2-level nesting (`fn() => function() {}`) and 3+ level deep nesting (`fn() => fn() => fn() => ...`).

**Before (bug):**

```php
$factory = fn() => static function() { return 'executed'; };
$closure = $factory();
$closure(); // 'executed'

// After serialization:
$restored = unserialize(serialize(new SerializableClosure($closure)))->getClosure();
$restored(); // Returns a Closure object, not 'executed'
```

**After (fix):**

```php
$restored(); // 'executed'
```

## Root cause

The token parser encounters `T_FN` first, enters short closure mode, and absorbs the entire inner `function() { ... }` as part of the fn's expression body. Only one candidate is collected (the outer fn), and with a single candidate the verification loop is skipped entirely. The inner closure gets the outer fn's code.

## Previous attempt

PR #142 attempted this fix with a 74-line `extractNestedClosure()` method. It was closed without comment.

## This fix

When a single candidate is a short closure (`fn`), checks whether the closure being serialized is actually a nested closure within it. If so, extracts the inner closure from after the `=>` operator via token parsing.

Three layers of safety:

1. **`isNestedClosure()` guard** - On PHP 8.4+, uses closure name pattern detection (`{closure:{closure:...}`) to skip extraction entirely when serializing the factory itself. On older PHP, falls through to the next checks (safe default).
2. **`extractNestedClosure()`** - Parses tokens after `=>` looking for `function`/`static`/`fn`. Returns null if the body doesn't start with a closure keyword. Recurses for 3+ level deep nesting.
3. **`verifyCandidateSignature()`** - Validates the extracted candidate against the actual closure's parameter count and captured variables.

Key differences from PR #142:
- Adds `verifyCandidateSignature()` check on the extracted candidate (safety net)
- Handles `static fn` as a nested short closure
- On PHP 8.4+, uses `isNestedClosure()` to avoid false positives when serializing the factory itself
- Handles 3+ level deep nesting (fixes #152)

**Call site change:** 4 lines
**New methods:** `isNestedClosure()` (~10 lines) + `extractNestedClosure()` (~60 lines)

## Affected patterns

```php
fn() => static function() { ... }             // silent no-op after deserialization
fn() => function() { ... }                    // silent no-op after deserialization
fn($x) => static function() use ($x) { ... }  // ArgumentCountError
fn() => fn() => ...                           // returns wrong closure
fn() => fn() => fn() => ...                   // 3+ levels: returns wrong closure
```

## Upstream

opis/closure 4.x has the same bug (tested on v4.5.0).

**Real-world patterns:**
- [larawhale/cms](https://github.com/larawhale/cms) (Laravel) uses `fn() => function() {}` as default query constraints.
- [TypesetterIO/typesetter](https://github.com/TypesetterIO/typesetter) (Laravel-adjacent, uses `Illuminate\Support\Arr`) uses `fn() => fn() => true` as content filter default.
- [dragomano/Light-Portal](https://github.com/dragomano/Light-Portal) uses `fn() => function() { ob_start(); ... }` as template callback factories.
- [NoemPHP/simple-website-example](https://github.com/NoemPHP/simple-website-example) uses `fn() => function() { ... }` as route handler factories.

## Testing

**In the PR:** 42 test cases covering fn=>function, fn=>fn, parameters, use(), return types, factory serialization, deep nesting (3+ levels), and regression guards across 3 serializer backends.

**Independent testing:** [JoshSalway/sc-151-tests](https://github.com/JoshSalway/sc-151-tests) with comprehensive + sanity suites.

## Test plan

- [x] fn() returning static function (getCode + serialize round-trip)
- [x] fn() returning regular function (getCode + serialize round-trip)
- [x] fn() returning fn() (nested arrow)
- [x] fn() returning fn() returning fn() (3+ level deep nesting)
- [x] fn with use clause (captured variable preserved)
- [x] fn with params returning function with use (variable forwarding)
- [x] fn returning function with return type (`: string`)
- [x] Factory fn itself still serializes correctly (regression guard for isNestedClosure)
- [x] Standalone fn() still works (regression guard)
- [x] Standalone function() still works (regression guard)
- [x] All 3 serializer backends (Native, Signed, Unsigned)
- [x] All existing tests pass (398 passed, 7 pre-existing failures on PHP 8.4)
- [x] PHPStan passes