### PR TITLE
[2.x] [docs] Update README caveats

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,8 @@ echo $closure(); // james;
 
 ### Caveats
 
-* Anonymous classes cannot be created within closures.
-* Attributes cannot be used within closures.
 * Serializing closures on REPL environments like Laravel Tinker is not supported.
-* Serializing closures that reference objects with readonly properties is not supported.
+* Multiple closures defined on the same source line with identical signatures may not be distinguishable after serialization. Place each closure on its own line to avoid this.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

Updates the Caveats section of the README. Three of the four listed caveats have been resolved and are no longer accurate:

**Removed (resolved):**
- "Anonymous classes cannot be created within closures." - Fixed in PR #75
- "Attributes cannot be used within closures." - Fixed in PRs #46, #113, #128
- "Serializing closures that reference objects with readonly properties is not supported." - Fixed in PRs #87, #96

**Kept:**
- REPL/Tinker limitation (architectural - the serializer needs source files to read closure code)

**Added:**
- Same-line closure limitation, as discussed in #136

All removed caveats were verified by testing on the current 2.x branch (PHP 8.4). Anonymous classes, attributes, and readonly properties all serialize and deserialize correctly.