### PR TITLE
[2.x] Fail-closed HMAC verification on deserialization

### DIFF
--- a/src/SerializableClosure.php
+++ b/src/SerializableClosure.php
@@ -121,6 +121,10 @@ class SerializableClosure
             throw new InvalidSignatureException();
         }
 
+        if (! Signed::$signer && $data['serializable'] instanceof Signed) {
+            throw new InvalidSignatureException();
+        }
+
         $this->serializable = $data['serializable'];
     }
 }

--- a/src/Serializers/Signed.php
+++ b/src/Serializers/Signed.php
@@ -79,7 +79,11 @@ class Signed implements Serializable
      */
     public function __unserialize($signature)
     {
-        if (static::$signer && ! static::$signer->verify($signature)) {
+        if (! static::$signer) {
+            throw new MissingSecretKeyException();
+        }
+
+        if (! static::$signer->verify($signature)) {
             throw new InvalidSignatureException();
         }
 

--- a/tests/SignedSerializerTest.php
+++ b/tests/SignedSerializerTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Laravel\SerializableClosure\Exceptions\InvalidSignatureException;
+use Laravel\SerializableClosure\Exceptions\MissingSecretKeyException;
 use Laravel\SerializableClosure\SerializableClosure;
 
 test('secure closure integrity fail', function () {
@@ -36,6 +37,5 @@ test('signed closure without signer', function () {
 
     $value = serialize(new SerializableClosure($closure));
     SerializableClosure::setSecretKey(null);
-    $closure = unserialize($value)->getClosure();
-    expect($closure())->toBeTrue();
-});
+    unserialize($value);
+})->throws(MissingSecretKeyException::class);


### PR DESCRIPTION
## Summary

Ensures `Signed::__unserialize()` throws `MissingSecretKeyException` when no signer is configured, rather than silently skipping HMAC verification. Adds a belt-and-suspenders check in `SerializableClosure::__unserialize()`.

## The problem

The previous behavior allowed a signed closure to be deserialized without any HMAC verification if the secret key was not set at deserialization time:

```php
SerializableClosure::setSecretKey('my-secret');
$serialized = serialize(new SerializableClosure(fn() => 'signed'));

SerializableClosure::setSecretKey(null);
$closure = unserialize($serialized)->getClosure(); // No exception, no verification
```

The conditional `if (static::$signer && ...)` silently skipped verification when the signer was null, making the signature protection fail-open.

## The fix

Split the conditional into two explicit checks:
1. If no signer is set, throw `MissingSecretKeyException` (fail-closed)
2. If signer is set but verification fails, throw `InvalidSignatureException`

This matches the serialize side, which already throws `MissingSecretKeyException` when no key is configured.

## Test plan

- [x] Deserializing signed closure without key now throws MissingSecretKeyException
- [x] Normal signed flow (sign + deserialize with same key) still works
- [x] Tampered payloads still throw InvalidSignatureException
- [x] Unsigned closures unaffected
- [x] All existing tests pass