### PR TITLE
fix: closure from inside anonymous migration

### DIFF
--- a/src/Serializers/Native.php
+++ b/src/Serializers/Native.php
@@ -126,7 +126,11 @@ class Native implements Serializable
         }
 
         if ($scope = $reflector->getClosureScopeClass()) {
-            $scope = $scope->name;
+            if (! $scope->isAnonymous() || $reflector->isBindingRequired() || $reflector->isScopeRequired()) {
+                $scope = $scope->name;
+            } else {
+                $scope = null;
+            }
         }
 
         $this->reference = spl_object_hash($this->closure);

--- a/tests/AnonymousClassScopeRegressionTest.php
+++ b/tests/AnonymousClassScopeRegressionTest.php
@@ -1,0 +1,41 @@
+<?php
+
+use Laravel\SerializableClosure\Serializers\Native;
+
+test('anonymous class static closure without scope requirements omits scope and round-trips', function (): void {
+    $factory = new class
+    {
+        public function makeClosure(): Closure
+        {
+            return static function (): string {
+                return 'serialized';
+            };
+        }
+    };
+
+    $native = new Native($factory->makeClosure());
+    $data = $native->__serialize();
+
+    expect($data['scope'])->toBeNull();
+
+    expect(s($factory->makeClosure())())->toBe('serialized');
+})->with('serializers');
+
+test('anonymous class closure keeps scope when it is required', function (): void {
+    $factory = new class
+    {
+        public function makeClosure(): Closure
+        {
+            return static function (): string {
+                return self::class;
+            };
+        }
+    };
+
+    $native = new Native($factory->makeClosure());
+    $data = $native->__serialize();
+
+    expect($data['scope'])
+        ->toBeString()
+        ->toContain('@anonymous');
+});


### PR DESCRIPTION
Hello!

I kept getting an error when trying to dispatch a closure from inside a migration, even when using a static closure with no references to the anonymous migration:

```php
return new class extends Migration
{
    public function up(): void
    {
        // stuf...
        dispatch(static function (): void {
            // other stuff
        });
    }
};
```

```
ErrorException: Class "Illuminate\Database\Migrations\Migration@anonymous" not found in /var/www/eaglesys/releases/263/vendor/laravel/serializable-closure/src/Serializers/Native.php:196
```

This fixes that by not capturing the scope if its not required.

Thanks!