### PR TITLE
[2.x] Restore nested closure in object property on unserialize

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -23,6 +23,7 @@
             <file>tests/ReflectionClosureEmptyTokensTest.php</file>
             <file>tests/TypedClosurePropertyTest.php</file>
             <file>tests/SerializeNestedClosureRegressionTest.php</file>
+            <file>tests/ReserializeNestedClosurePropertyTest.php</file>
             <file>tests/InstanceofExpressionTest.php</file>
             <file>tests/MultipleClosuresOnSameLineTest.php</file>
         </testsuite>

--- a/src/Serializers/Native.php
+++ b/src/Serializers/Native.php
@@ -363,6 +363,8 @@ class Native implements Serializable
             foreach ($data as $key => &$value) {
                 if ($value instanceof SelfReference && $value->hash === $this->code['self']) {
                     $data->{$key} = &$this->closure;
+                } elseif ($value instanceof static) {
+                    $data->{$key} = &$value->closure;
                 } elseif (is_array($value) || is_object($value)) {
                     $this->mapPointers($value);
                 }
@@ -399,6 +401,8 @@ class Native implements Serializable
                             'property' => $property,
                             'object' => $item instanceof SelfReference ? $this : $item,
                         ];
+                    } elseif ($item instanceof static) {
+                        static::setPropertyValue($property, $data, $item->closure);
                     } elseif (is_array($item) || is_object($item)) {
                         $this->mapPointers($item);
                         static::setPropertyValue($property, $data, $item);

--- a/tests/ReserializeNestedClosurePropertyTest.php
+++ b/tests/ReserializeNestedClosurePropertyTest.php
@@ -1,0 +1,64 @@
+<?php
+
+use Laravel\SerializableClosure\SerializableClosure;
+use Laravel\SerializableClosure\Serializers;
+use Laravel\SerializableClosure\UnsignedSerializableClosure;
+use Tests\Fixtures\ClassWithSerializableClosureProperty;
+
+/**
+ * Regression test for https://github.com/laravel/serializable-closure/issues/161.
+ *
+ * A closure nested in an object (or stdClass) property is wrapped into a bare
+ * Serializers\Native on serialize. On unserialize it must be restored to a real
+ * Closure, otherwise the next serialize() treats the Native as a closure and
+ * throws "must be of type Closure, ...\Serializers\Native given".
+ */
+function reserializeWrap($closure, $serializer)
+{
+    switch ($serializer) {
+        case Serializers\Signed::class:
+            SerializableClosure::setSecretKey('secret');
+
+            return new SerializableClosure($closure);
+        case UnsignedSerializableClosure::class:
+            return SerializableClosure::unsigned($closure);
+        default:
+            return new SerializableClosure($closure);
+    }
+}
+
+test('closure in object property is restored to a real closure and survives re-serialization', function ($serializer) {
+    $holder = new ClassWithSerializableClosureProperty(fn () => 'hello');
+
+    $wrapped = reserializeWrap(fn () => $holder, $serializer);
+
+    $wrapped = unserialize(serialize($wrapped));
+    $resolved = ($wrapped->getClosure())();
+
+    expect($resolved->closure)->toBeInstanceOf(Closure::class);
+    expect(($resolved->closure)())->toBe('hello');
+
+    // Re-serializing must not throw and must keep working.
+    $reWrapped = unserialize(serialize($wrapped));
+    $reResolved = ($reWrapped->getClosure())();
+
+    expect(($reResolved->closure)())->toBe('hello');
+})->with('serializers');
+
+test('closure in stdClass property is restored and survives re-serialization', function ($serializer) {
+    $obj = new stdClass();
+    $obj->fn = fn () => 'world';
+
+    $wrapped = reserializeWrap(fn () => $obj, $serializer);
+
+    $wrapped = unserialize(serialize($wrapped));
+    $resolved = ($wrapped->getClosure())();
+
+    expect($resolved->fn)->toBeInstanceOf(Closure::class);
+    expect(($resolved->fn)())->toBe('world');
+
+    $reWrapped = unserialize(serialize($wrapped));
+    $reResolved = ($reWrapped->getClosure())();
+
+    expect(($reResolved->fn)())->toBe('world');
+})->with('serializers');


### PR DESCRIPTION
## Summary
A closure nested in an object (or `stdClass`) property is wrapped into a bare `Serializers\Native` on serialize. On unserialize, `mapPointers()` restored this correctly for arrays but **not** for object/`stdClass` properties — the property kept holding the `Native`. The next `serialize()` then passed the `Native` to `new ReflectionClosure()`, throwing `must be of type Closure, ...\Serializers\Native given`. This breaks multi-tier caches (e.g. Symfony's `ChainAdapter`) that re-serialize cached values.

## Fix
Convert bare `Native` instances back to real closures in the object-property and `stdClass` branches of `mapPointers()`, mirroring the existing array handling.

## Tests
Added `tests/ReserializeNestedClosurePropertyTest.php` covering closures nested in object and `stdClass` properties, across all three serializers, including a double serialize → unserialize → serialize round-trip. Full suite: 400 passed.
 
Fixed #161