### PR TITLE
[2.x] Fix identical-signature closures on the same line resolving to the first candidate

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -3,6 +3,7 @@ php:
   preset: laravel
   finder:
     not-name:
+      - MultipleClosuresOnSameLineTest.php
       - Php84Test.php
       - ReflectionClosureBracedNamespaceTest.php
       - ReflectionClosureNonBracedNamespaceTest.php

--- a/src/Support/ReflectionClosure.php
+++ b/src/Support/ReflectionClosure.php
@@ -7,6 +7,7 @@ use ReflectionFunction;
 
 class ReflectionClosure extends ReflectionFunction
 {
+    protected $closure;
     protected $code;
     protected $tokens;
     protected $hashedName;
@@ -23,6 +24,20 @@ class ReflectionClosure extends ReflectionFunction
     protected static $structures = [];
 
     /**
+     * Candidate indexes previously assigned to closure instances.
+     *
+     * @var \WeakMap<\Closure, int>|null
+     */
+    protected static $candidateIndexes;
+
+    /**
+     * Counts closures seen per file / line range / candidate group.
+     *
+     * @var array<string, int>
+     */
+    protected static $candidateCounters = [];
+
+    /**
      * Creates a new reflection closure instance.
      *
      * @param  \Closure  $closure
@@ -32,6 +47,8 @@ class ReflectionClosure extends ReflectionFunction
     public function __construct(Closure $closure, $code = null)
     {
         parent::__construct($closure);
+
+        $this->closure = $closure;
     }
 
     /**
@@ -777,35 +794,30 @@ class ReflectionClosure extends ReflectionFunction
             return "#[$name($arguments)]";
         }, $this->getAttributes())));
 
+        $selected = null;
+
         if (count($candidates) > 1) {
-            $lastItem = array_pop($candidates);
+            $verified = array_values(array_filter($candidates, function ($candidate) {
+                return $this->verifyCandidateSignature($candidate);
+            }));
 
-            foreach ($candidates as $candidate) {
-                if (! $this->verifyCandidateSignature($candidate)) {
-                    continue;
-                }
-
-                $this->applyCandidate($candidate);
-
-                $code = $candidate['code'];
-
-                if (! empty($attributesCode)) {
-                    $code = implode("\n", array_merge($attributesCode, [$code]));
-                }
-
-                $this->code = $code;
-
-                return $this->code;
+            if (count($verified) === 1) {
+                $selected = $verified[0];
+            } elseif (count($verified) > 1) {
+                // Multiple closures with identical signatures exist on the same
+                // line. Reflection cannot tell them apart, so candidates are
+                // assigned to closure instances in the order they are first seen.
+                $selected = $verified[$this->resolveCandidateIndex($verified)];
             }
-
-            $candidates[] = $lastItem;
         }
 
-        $lastItem = array_pop($candidates);
+        if ($selected === null) {
+            $selected = array_pop($candidates);
+        }
 
-        if ($lastItem) {
-            $this->applyCandidate($lastItem);
-            $code = $lastItem['code'];
+        if ($selected) {
+            $this->applyCandidate($selected);
+            $code = $selected['code'];
         } else {
             if ($isShortClosure) {
                 $this->useVariables = $this->getStaticVariables();
@@ -1398,6 +1410,34 @@ class ReflectionClosure extends ReflectionFunction
             'closureArgsInnerFuncCount' => 0,
             'closureArgsBraceDepth' => 0,
         ];
+    }
+
+    /**
+     * Resolve which of the verified candidates belongs to this closure.
+     *
+     * Closures with identical signatures on the same line are indistinguishable
+     * through reflection, so candidates are assigned to closure instances in the
+     * order in which they are first serialized. The assigned index is cached per
+     * closure instance so repeated serializations remain stable.
+     *
+     * @param  array  $verified
+     * @return int
+     */
+    protected function resolveCandidateIndex($verified)
+    {
+        static::$candidateIndexes ??= new \WeakMap;
+
+        if (isset(static::$candidateIndexes[$this->closure])) {
+            return static::$candidateIndexes[$this->closure] % count($verified);
+        }
+
+        $key = $this->getFileName().':'.$this->getStartLine().':'.$this->getEndLine().':'.md5(implode("\x00", array_column($verified, 'code')));
+
+        $index = static::$candidateCounters[$key] ?? 0;
+
+        static::$candidateCounters[$key] = $index + 1;
+
+        return static::$candidateIndexes[$this->closure] = $index % count($verified);
     }
 
     /**

--- a/tests/MultipleClosuresOnSameLineTest.php
+++ b/tests/MultipleClosuresOnSameLineTest.php
@@ -94,6 +94,57 @@ test('multiple traditional closures on same line', function () {
     expect($u2())->toBe(2);
 });
 
+test('multiple closures on same line with identical signatures', function () {
+    $closures = [fn () => 'a', fn () => 'b', fn () => 'c'];
+
+    $serialized = serialize(array_map(fn ($c) => new SerializableClosure($c), $closures));
+    $unserialized = array_map(fn ($sc) => $sc->getClosure(), unserialize($serialized));
+
+    expect($unserialized[0]())->toBe('a');
+    expect($unserialized[1]())->toBe('b');
+    expect($unserialized[2]())->toBe('c');
+});
+
+test('closure with identical signature keeps its candidate on repeated serialization', function () {
+    $closures = [fn () => 'x', fn () => 'y'];
+
+    $s1 = new SerializableClosure($closures[0]);
+    $s2 = new SerializableClosure($closures[1]);
+
+    expect(unserialize(serialize($s1))->getClosure()())->toBe('x');
+    expect(unserialize(serialize($s2))->getClosure()())->toBe('y');
+
+    // Serializing the same instances again must yield the same results.
+    expect(unserialize(serialize($s1))->getClosure()())->toBe('x');
+    expect(unserialize(serialize($s2))->getClosure()())->toBe('y');
+});
+
+test('multiple traditional closures with identical signatures on same line', function () {
+    $c1 = function () { return 1; }; $c2 = function () { return 2; }; // @phpstan-ignore-line
+
+    $u1 = unserialize(serialize(new SerializableClosure($c1)))->getClosure();
+    $u2 = unserialize(serialize(new SerializableClosure($c2)))->getClosure();
+
+    expect($u1())->toBe(1);
+    expect($u2())->toBe(2);
+});
+
+test('identical signature closures created in a loop', function () {
+    $all = [];
+
+    for ($i = 0; $i < 2; $i++) {
+        $pair = [fn () => 'first', fn () => 'second'];
+
+        $all[] = unserialize(serialize(new SerializableClosure($pair[0])))->getClosure();
+        $all[] = unserialize(serialize(new SerializableClosure($pair[1])))->getClosure();
+    }
+
+    expect($all[0]())->toBe('first');
+    expect($all[1]())->toBe('second');
+    expect($all[2]())->toBe('first');
+    expect($all[3]())->toBe('second');
+});
+
 test('multiple traditional closures with use clause on same line', function () {
     $a = 1;
     $b = 2;


### PR DESCRIPTION
Fixes #131

## Summary

Fixes the remaining edge case from #120 where multiple closures defined on the same source line with **identical signatures** all serialize as the first closure.

PR #120 introduced candidate collection and `verifyCandidateSignature()` to distinguish closures on the same line with different signatures. When signatures match, every candidate passes verification and the first one was always selected — so `[fn() => 'a', fn() => 'b', fn() => 'c']` round-tripped as `a, a, a`.

This change assigns verified candidates to closure instances in first-seen order and caches the index per closure instance (via `WeakMap`) so repeated serialization stays stable.

@JoshSalway could you take a look and confirm whether this fixes your issue in #131?

## Approach

PHP reflection only exposes line numbers, not column positions, so identical-signature closures on the same line are indistinguishable through reflection alone. The fix follows the same heuristic used in the upstream PoC ([opis/closure#165](https://github.com/opis/closure/pull/165)):

- When multiple candidates pass signature verification, pick the candidate at `resolveCandidateIndex()`
- Index is assigned on first serialization, keyed by `file:startLine:endLine` and a hash of the verified candidate group
- The assigned index is cached per closure instance for stable re-serialization

## Limitation

This assumes closures are serialized in source order (e.g. `array_map`, job chains, pipeline stages). Serializing only the second of two identical-signature closures on a line without ever serializing the first may still pick the wrong candidate — that case was already broken and cannot be fixed without column information from PHP itself.

## Test plan

- [x] `vendor/bin/pest tests/MultipleClosuresOnSameLineTest.php`
- [x] `vendor/bin/pest` (full suite)
- [x] `vendor/bin/phpstan analyse`
- [x] Verified new tests fail without the fix (4 failures reproducing `a, a, a` behavior)