### PR TITLE
Fix nested SerializableClosure in array property becoming a plain Closure

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -24,6 +24,7 @@
             <file>tests/TypedClosurePropertyTest.php</file>
             <file>tests/SerializeNestedClosureRegressionTest.php</file>
             <file>tests/ReserializeNestedClosurePropertyTest.php</file>
+            <file>tests/NestedSerializableClosureInArrayPropertyTest.php</file>
             <file>tests/InstanceofExpressionTest.php</file>
             <file>tests/MultipleClosuresOnSameLineTest.php</file>
         </testsuite>

--- a/src/Serializers/Native.php
+++ b/src/Serializers/Native.php
@@ -328,6 +328,10 @@ class Native implements Serializable
      */
     protected function mapPointers(&$data)
     {
+        if ($data instanceof SerializableClosure || $data instanceof UnsignedSerializableClosure) {
+            return;
+        }
+
         $scope = $this->scope;
 
         if ($data instanceof static) {

--- a/tests/NestedSerializableClosureInArrayPropertyTest.php
+++ b/tests/NestedSerializableClosureInArrayPropertyTest.php
@@ -42,11 +42,11 @@ test('SerializableClosure nested in an array property stays a SerializableClosur
     $resolved = ($wrapped->getClosure())();
 
     expect($resolved->callbacks[0])->toBeInstanceOf($serializer === UnsignedSerializableClosure::class ? UnsignedSerializableClosure::class : SerializableClosure::class);
-    expect(($resolved->callbacks[0])->getClosure()())->toBe('hello');
+    expect($resolved->callbacks[0]->getClosure()())->toBe('hello');
 
     // Must still be serializable a second time.
     $reWrapped = unserialize(serialize($wrapped));
     $reResolved = ($reWrapped->getClosure())();
 
-    expect(($reResolved->callbacks[0])->getClosure()())->toBe('hello');
+    expect($reResolved->callbacks[0]->getClosure()())->toBe('hello');
 })->with('serializers');

--- a/tests/NestedSerializableClosureInArrayPropertyTest.php
+++ b/tests/NestedSerializableClosureInArrayPropertyTest.php
@@ -1,0 +1,52 @@
+<?php
+
+use Laravel\SerializableClosure\SerializableClosure;
+use Laravel\SerializableClosure\Serializers;
+use Laravel\SerializableClosure\UnsignedSerializableClosure;
+
+/**
+ * Regression test for a SerializableClosure nested inside an array that lives
+ * on an object property. Fixing #161 introduced a side effect where such a
+ * nested SerializableClosure gets replaced by a plain Closure on unserialize,
+ * which then fails to serialize again ("Serialization of 'Closure' is not
+ * allowed"), because a SerializableClosure always needs to stay wrapped.
+ */
+class ObjectWithCallbacksProperty
+{
+    public $callbacks = [];
+}
+
+function wrapWith($closure, $serializer)
+{
+    switch ($serializer) {
+        case Serializers\Signed::class:
+            SerializableClosure::setSecretKey('secret');
+
+            return new SerializableClosure($closure);
+        case UnsignedSerializableClosure::class:
+            return SerializableClosure::unsigned($closure);
+        default:
+            return new SerializableClosure($closure);
+    }
+}
+
+test('SerializableClosure nested in an array property stays a SerializableClosure after unserialize', function ($serializer) {
+    $holder = new ObjectWithCallbacksProperty();
+    $holder->callbacks = [
+        wrapWith(fn () => 'hello', $serializer),
+    ];
+
+    $wrapped = wrapWith(fn () => $holder, $serializer);
+
+    $wrapped = unserialize(serialize($wrapped));
+    $resolved = ($wrapped->getClosure())();
+
+    expect($resolved->callbacks[0])->toBeInstanceOf($serializer === UnsignedSerializableClosure::class ? UnsignedSerializableClosure::class : SerializableClosure::class);
+    expect(($resolved->callbacks[0])->getClosure()())->toBe('hello');
+
+    // Must still be serializable a second time.
+    $reWrapped = unserialize(serialize($wrapped));
+    $reResolved = ($reWrapped->getClosure())();
+
+    expect(($reResolved->callbacks[0])->getClosure()())->toBe('hello');
+})->with('serializers');


### PR DESCRIPTION
Fixes #171.

`mapPointers()` was also walking into `SerializableClosure`/`UnsignedSerializableClosure` objects it found while restoring a parent closure, and overwriting their internal `serializable` property with a bare `Closure`. This skips that: those two classes already restore themselves correctly through their own `__unserialize()`, so `mapPointers()` doesn't need to touch them.

Added a regression test, and confirmed #161's own tests and the full suite still pass.

cc @taylorotwell 