### PR TITLE
[2.x] Ensure `$signer` is configured before attempting to execute `unserialize()`

### DIFF
--- a/src/Serializers/Signed.php
+++ b/src/Serializers/Signed.php
@@ -57,6 +57,8 @@ class Signed implements Serializable
      * Get the serializable representation of the closure.
      *
      * @return array
+     *
+     * @throws \Laravel\SerializableClosure\Exceptions\MissingSecretKeyException
      */
     public function __serialize()
     {
@@ -76,10 +78,15 @@ class Signed implements Serializable
      * @return void
      *
      * @throws \Laravel\SerializableClosure\Exceptions\InvalidSignatureException
+     * @throws \Laravel\SerializableClosure\Exceptions\MissingSecretKeyException
      */
     public function __unserialize($signature)
     {
-        if (static::$signer && ! static::$signer->verify($signature)) {
+        if (! static::$signer) {
+            throw new MissingSecretKeyException();
+        }
+
+        if (! static::$signer->verify($signature)) {
             throw new InvalidSignatureException();
         }
 

--- a/tests/SignedSerializerTest.php
+++ b/tests/SignedSerializerTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Laravel\SerializableClosure\Exceptions\InvalidSignatureException;
+use Laravel\SerializableClosure\Exceptions\MissingSecretKeyException;
 use Laravel\SerializableClosure\SerializableClosure;
 
 test('secure closure integrity fail', function () {
@@ -36,6 +37,5 @@ test('signed closure without signer', function () {
 
     $value = serialize(new SerializableClosure($closure));
     SerializableClosure::setSecretKey(null);
-    $closure = unserialize($value)->getClosure();
-    expect($closure())->toBeTrue();
-});
+    $closure = unserialize($value);
+})->throws(MissingSecretKeyException::class);


### PR DESCRIPTION


`Signed::__serialize()` would throw `MissingSecretKeyException` when `$signer` is not configured. `__unserialize()` should guard using the same format

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
