### PR TITLE
[2.x] Fix uninitialized internal state when serializing subclasses of PHP internal classes

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -27,6 +27,7 @@
             <file>tests/NestedSerializableClosureInArrayPropertyTest.php</file>
             <file>tests/InstanceofExpressionTest.php</file>
             <file>tests/MultipleClosuresOnSameLineTest.php</file>
+            <file>tests/InternalAncestryRegressionTest.php</file>
         </testsuite>
         <testsuite name="php81">
             <file phpVersion="8.1.0" phpVersionOperator=">=">tests/ReflectionClosurePhp80Test.php</file>

--- a/src/Serializers/Native.php
+++ b/src/Serializers/Native.php
@@ -265,7 +265,7 @@ class Native implements Serializable
             $instance = $data;
             $reflection = new ReflectionObject($instance);
 
-            if (! $reflection->isUserDefined()) {
+            if (! $reflection->isUserDefined() || static::hasInternalAncestry($reflection)) {
                 $storage[$instance] = $data;
 
                 return;
@@ -497,7 +497,7 @@ class Native implements Serializable
 
             $reflection = new ReflectionObject($data);
 
-            if (! $reflection->isUserDefined()) {
+            if (! $reflection->isUserDefined() || static::hasInternalAncestry($reflection)) {
                 $this->scope[$instance] = $data;
 
                 return;
@@ -564,6 +564,32 @@ class Native implements Serializable
         PHP_VERSION_ID >= 80400
             ? $property->setRawValue($object, $value)
             : $property->setValue($object, $value);
+    }
+
+    /**
+     * Determine if the class inherits from a PHP internal class.
+     *
+     * Instances of such classes carry internal state that
+     * newInstanceWithoutConstructor() cannot rebuild (e.g. DateTime
+     * subclasses like Carbon), so they must be kept as-is instead of
+     * being reconstructed property by property.
+     *
+     * @param  \ReflectionObject  $reflection
+     * @return bool
+     */
+    protected static function hasInternalAncestry(ReflectionObject $reflection): bool
+    {
+        $class = $reflection->getParentClass();
+
+        while ($class !== false) {
+            if ($class->isInternal()) {
+                return true;
+            }
+
+            $class = $class->getParentClass();
+        }
+
+        return false;
     }
 
     /**

--- a/tests/Fixtures/ClassWithCarbonProperty.php
+++ b/tests/Fixtures/ClassWithCarbonProperty.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tests\Fixtures;
+
+use Carbon\CarbonImmutable;
+use Closure;
+
+/**
+ * Simulates a class like an Eloquent model that holds a Carbon date and is
+ * captured by a closure (e.g. via Bus::chain), requiring the library to
+ * serialize an object whose class inherits from a PHP internal class.
+ */
+class ClassWithCarbonProperty
+{
+    public CarbonImmutable $paidAt;
+
+    public function __construct(CarbonImmutable $paidAt)
+    {
+        $this->paidAt = $paidAt;
+    }
+
+    public function makeClosure(): Closure
+    {
+        return fn () => $this->paidAt->toIso8601String();
+    }
+}

--- a/tests/Fixtures/CustomCollection.php
+++ b/tests/Fixtures/CustomCollection.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Tests\Fixtures;
+
+use ArrayObject;
+
+/**
+ * A userland subclass of an internal class that stores its state internally
+ * rather than in userland properties. Rebuilding it property by property
+ * silently drops the internal storage.
+ */
+class CustomCollection extends ArrayObject
+{
+    //
+}

--- a/tests/Fixtures/CustomDate.php
+++ b/tests/Fixtures/CustomDate.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Tests\Fixtures;
+
+use DateTimeImmutable;
+
+/**
+ * A userland subclass of a PHP internal class. Its internal state cannot be
+ * rebuilt by newInstanceWithoutConstructor(), so the serializer must keep
+ * instances as-is instead of reconstructing them property by property.
+ */
+class CustomDate extends DateTimeImmutable
+{
+    //
+}

--- a/tests/InternalAncestryRegressionTest.php
+++ b/tests/InternalAncestryRegressionTest.php
@@ -1,0 +1,58 @@
+<?php
+
+use Carbon\CarbonImmutable;
+use Tests\Fixtures\ClassWithCarbonProperty;
+use Tests\Fixtures\CustomDate;
+
+/**
+ * Regression test for https://github.com/laravel/serializable-closure/issues/109.
+ *
+ * Objects whose class inherits from a PHP internal class (e.g. Carbon
+ * extending DateTimeImmutable) carry internal state that
+ * newInstanceWithoutConstructor() cannot rebuild. Reconstructing them
+ * property by property produces uninitialized instances that fail with
+ * "has not been correctly initialized by calling parent::__construct()".
+ *
+ * The guard added in v2.0.9 for this was removed in v2.0.11 (#129),
+ * reintroducing the crash for Bus::chain closures capturing models
+ * with Carbon date attributes.
+ */
+test('closures capturing objects with carbon properties can be serialized', function () {
+    $obj = new ClassWithCarbonProperty(CarbonImmutable::parse('2026-01-01 12:00:00', 'UTC'));
+
+    $closure = function () use ($obj) {
+        return $obj->paidAt->toIso8601String();
+    };
+
+    expect(s($closure)())->toBe('2026-01-01T12:00:00+00:00');
+})->with('serializers');
+
+test('closures bound to objects with carbon properties can be serialized', function () {
+    $obj = new ClassWithCarbonProperty(CarbonImmutable::parse('2026-01-01 12:00:00', 'UTC'));
+
+    expect(s($obj->makeClosure())())->toBe('2026-01-01T12:00:00+00:00');
+})->with('serializers');
+
+test('userland subclasses of internal classes survive serialization intact', function () {
+    $obj = new CustomDate('2026-01-01 12:00:00', new DateTimeZone('Europe/Amsterdam'));
+
+    $closure = function () use ($obj) {
+        return $obj->format('Y-m-d H:i:s e');
+    };
+
+    expect(s($closure)())->toBe('2026-01-01 12:00:00 Europe/Amsterdam');
+})->with('serializers');
+
+test('carbon instances keep their value and timezone after round trip', function () {
+    $obj = new ClassWithCarbonProperty(CarbonImmutable::parse('2026-06-15 08:30:00', 'America/New_York'));
+
+    $closure = function () use ($obj) {
+        return $obj->paidAt;
+    };
+
+    $restored = s($closure)();
+
+    expect($restored)->toBeInstanceOf(CarbonImmutable::class);
+    expect($restored->format('Y-m-d H:i:s'))->toBe('2026-06-15 08:30:00');
+    expect($restored->timezoneName)->toBe('America/New_York');
+})->with('serializers');

--- a/tests/InternalAncestryRegressionTest.php
+++ b/tests/InternalAncestryRegressionTest.php
@@ -2,6 +2,7 @@
 
 use Carbon\CarbonImmutable;
 use Tests\Fixtures\ClassWithCarbonProperty;
+use Tests\Fixtures\CustomCollection;
 use Tests\Fixtures\CustomDate;
 
 /**
@@ -41,6 +42,16 @@ test('userland subclasses of internal classes survive serialization intact', fun
     };
 
     expect(s($closure)())->toBe('2026-01-01 12:00:00 Europe/Amsterdam');
+})->with('serializers');
+
+test('userland subclasses of internal classes keep their internal storage', function () {
+    $obj = new CustomCollection(['a', 'b', 'c']);
+
+    $closure = function () use ($obj) {
+        return $obj->getArrayCopy();
+    };
+
+    expect(s($closure)())->toBe(['a', 'b', 'c']);
 })->with('serializers');
 
 test('carbon instances keep their value and timezone after round trip', function () {


### PR DESCRIPTION
Fixes a regression of #109 that was reintroduced in v2.0.11: serializing a closure bound to an object that holds a Carbon date (or any instance of a userland class inheriting from a PHP internal class) crashes with:

```
DateObjectError: Object of type Carbon\CarbonImmutable (inheriting DateTimeImmutable) has not been correctly initialized by calling parent::__construct() in its constructor
```

A very common real-world trigger is `Bus::chain` with a closure capturing an Eloquent model that has Carbon date attributes. In our app this deterministically broke CI the moment any composer update moved serializable-closure past v2.0.10.

## Problem

`wrapClosures()` and `mapByReference()` rebuild user-defined objects with `newInstanceWithoutConstructor()` and copy their properties one by one. Instances of classes that inherit from PHP internal classes carry internal engine state that reflection cannot rebuild, so the copy is a hollow object.

The protection for this is currently incomplete and was partially removed:

- #55 added an `instanceof DateTimeInterface` guard, but only in `mapByReference()`. That is why `use ($carbonHolder)` captures survive while `$this`-bound closures crash: the bound object's Carbon property is reached through `wrapClosures()`, which has no such guard. #109 described exactly this split ("#55 fixes this problem if the Carbon variable is in the function (use-scope), but not in the instance").
- v2.0.9 (#122) fixed #109 by skipping objects with `__serialize`, but that was too broad and broke nested closures in array properties (#126).
- v2.0.11 (#129) fixed #126 by removing the #122 guard entirely, which reintroduced the #109 crash.

The date guard from #55 is also too narrow: any userland subclass of an internal class that keeps state internally is affected. For example an `ArrayObject` subclass captured via `use` currently loses its internal storage silently and comes back empty (covered by a new test).

## Solution

Add a `hasInternalAncestry()` guard at both `newInstanceWithoutConstructor()` call sites: objects whose class hierarchy includes a PHP internal class are kept as-is and left to native serialization (Carbon, ArrayObject and friends handle their own `__serialize`). This generalizes #55's `DateTimeInterface` special case, which is left in place, and covers the `wrapClosures()` path it missed.

Ordinary userland objects, including ones with `__serialize` and closures in array properties (the #126 case), are still walked and wrapped, so #126 does not regress: the full existing suite passes.

Trade-off, for the record: closures stored in userland properties of internal-class subclasses are no longer wrapped. Serializing those was already unsound (the object's internal state was dropped in the process), so nothing that worked before breaks.

## Repro (fails on 2.x, passes with this PR)

```php
class Invoice {
    public \Carbon\CarbonImmutable $paidAt;

    public function __construct()
    {
        $this->paidAt = \Carbon\CarbonImmutable::parse('2026-01-01 12:00:00');
    }

    public function makeClosure(): \Closure
    {
        return fn () => $this->paidAt->toIso8601String();
    }
}

serialize(new SerializableClosure((new Invoice())->makeClosure())); // DateObjectError
```
