### PR TITLE
Supports PHP 8.6

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         php: [8.1, 8.2, 8.3, 8.4, 8.5]
         laravel: [10, 11, 12, 13]
-        experimental: false
+        experimental: [false]
         exclude:
           - php: 8.1
             laravel: 11

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,10 +16,10 @@ permissions:
 jobs:
   linux_tests:
     runs-on: ubuntu-24.04
+    continue-on-error: ${{ matrix.experimental }}
 
     strategy:
       fail-fast: true
-      continue-on-error: ${{ matrix.experimental }}
       matrix:
         php: [8.1, 8.2, 8.3, 8.4, 8.5]
         laravel: [10, 11, 12, 13]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,9 +19,11 @@ jobs:
 
     strategy:
       fail-fast: true
+      continue-on-error: ${{ matrix.experimental }}
       matrix:
         php: [8.1, 8.2, 8.3, 8.4, 8.5]
         laravel: [10, 11, 12, 13]
+        experimental: false
         exclude:
           - php: 8.1
             laravel: 11
@@ -37,6 +39,9 @@ jobs:
             laravel: 10
           - php: 8.5
             laravel: 11
+          - php: 8.6
+            laravel: 13
+            experimental: true
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
 
@@ -60,7 +65,7 @@ jobs:
           echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
       - name: Install PHP dependencies
-        run: composer update --prefer-stable --no-interaction --no-progress --with="illuminate/support:^${{ matrix.laravel }}"
+        run: composer update --prefer-stable --no-interaction --no-progress --with="illuminate/support:^${{ matrix.laravel }}" ${{ matrix.experimental == true && '--ignore-platform-reqs' || '' }}
 
       - name: Execute tests
         run: vendor/bin/pest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,6 +24,10 @@ jobs:
         php: [8.1, 8.2, 8.3, 8.4, 8.5]
         laravel: [10, 11, 12, 13]
         experimental: [false]
+        include:
+          - php: 8.6
+            laravel: 13
+            experimental: true
         exclude:
           - php: 8.1
             laravel: 11
@@ -39,9 +43,6 @@ jobs:
             laravel: 10
           - php: 8.5
             laravel: 11
-          - php: 8.6
-            laravel: 13
-            experimental: true
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
 

--- a/src/Serializers/Native.php
+++ b/src/Serializers/Native.php
@@ -133,7 +133,9 @@ class Native implements Serializable
             }
         }
 
-        $this->reference = spl_object_hash($this->closure);
+        $this->reference = version_compare(PHP_VERSION, '8.6.0', '>=')
+            ? spl_object_id($this->closure)
+            : spl_object_hash($this->closure);
 
         $this->scope[$this->closure] = $this;
 

--- a/src/Serializers/Native.php
+++ b/src/Serializers/Native.php
@@ -133,9 +133,7 @@ class Native implements Serializable
             }
         }
 
-        $this->reference = PHP_VERSION === '8.6.0-dev' || version_compare(PHP_VERSION, '8.6.0', '>=')
-            ? spl_object_id($this->closure)
-            : spl_object_hash($this->closure);
+        $this->reference = spl_object_id($this->closure);
 
         $this->scope[$this->closure] = $this;
 

--- a/src/Serializers/Native.php
+++ b/src/Serializers/Native.php
@@ -55,7 +55,7 @@ class Native implements Serializable
     /**
      * The closure's reference.
      *
-     * @var string
+     * @var string|int
      */
     protected $reference;
 
@@ -133,7 +133,9 @@ class Native implements Serializable
             }
         }
 
-        $this->reference = spl_object_id($this->closure);
+        $this->reference = PHP_VERSION_ID >= 80600
+            ? spl_object_id($this->closure)
+            : spl_object_hash($this->closure);
 
         $this->scope[$this->closure] = $this;
 

--- a/src/Serializers/Native.php
+++ b/src/Serializers/Native.php
@@ -133,7 +133,7 @@ class Native implements Serializable
             }
         }
 
-        $this->reference = version_compare(PHP_VERSION, '8.6.0', '>=')
+        $this->reference = PHP_VERSION === '8.6.0-dev' || version_compare(PHP_VERSION, '8.6.0', '>=')
             ? spl_object_id($this->closure)
             : spl_object_hash($this->closure);
 

--- a/src/Support/SelfReference.php
+++ b/src/Support/SelfReference.php
@@ -7,14 +7,14 @@ class SelfReference
     /**
      * The unique hash representing the object.
      *
-     * @var string
+     * @var string|int
      */
     public $hash;
 
     /**
      * Creates a new self reference instance.
      *
-     * @param  string  $hash
+     * @param  string|int  $hash
      * @return void
      */
     public function __construct($hash)

--- a/tests/SerializerTest.php
+++ b/tests/SerializerTest.php
@@ -365,9 +365,9 @@ test('serializable closure serialization string content dont change', function (
     $actual = explode('s:32:', serialize($c))[0];
 
     expect($actual)->toBe(<<<OEF
-O:47:"Laravel\SerializableClosure\SerializableClosure":1:{s:12:"serializable";O:46:"Laravel\SerializableClosure\Serializers\Signed":2:{s:12:"serializable";s:264:"O:46:"Laravel\SerializableClosure\Serializers\Native":5:{s:3:"use";a:1:{s:1:"a";i:100;}s:8:"function";s:47:"function () use (\$a) {
+O:47:"Laravel\SerializableClosure\SerializableClosure":1:{s:12:"serializable";O:46:"Laravel\SerializableClosure\Serializers\Signed":2:{s:12:"serializable";s:231:"O:46:"Laravel\SerializableClosure\Serializers\Native":5:{s:3:"use";a:1:{s:1:"a";i:100;}s:8:"function";s:47:"function () use (\$a) {
         return \$a;
-    }";s:5:"scope";s:22:"P\Tests\SerializerTest";s:4:"this";N;s:4:"self";
+    }";s:5:"scope";s:22:"P\Tests\SerializerTest";s:4:"this";N;s:4:"self";i:6838;}";s:4:"hash";s:44:"+1lcRO0lDFgbghMrNFtILaGX/14VC8WpQYXUwpIjwVQ=";}}
 OEF
     );
 });
@@ -386,7 +386,7 @@ test('unsigned serializable closure serialization string content dont change', f
     expect($actual)->toBe(<<<OEF
 O:55:"Laravel\SerializableClosure\UnsignedSerializableClosure":1:{s:12:"serializable";O:46:"Laravel\SerializableClosure\Serializers\Native":5:{s:3:"use";a:1:{s:1:"a";i:100;}s:8:"function";s:47:"function () use (\$a) {
         return \$a;
-    }";s:5:"scope";s:22:"P\Tests\SerializerTest";s:4:"this";N;s:4:"self";
+    }";s:5:"scope";s:22:"P\Tests\SerializerTest";s:4:"this";N;s:4:"self";i:2551;}}
 OEF
     );
 });

--- a/tests/SerializerTest.php
+++ b/tests/SerializerTest.php
@@ -365,9 +365,9 @@ test('serializable closure serialization string content dont change', function (
     $actual = explode('s:32:', serialize($c))[0];
 
     expect($actual)->toBe(<<<OEF
-O:47:"Laravel\SerializableClosure\SerializableClosure":1:{s:12:"serializable";O:46:"Laravel\SerializableClosure\Serializers\Signed":2:{s:12:"serializable";s:231:"O:46:"Laravel\SerializableClosure\Serializers\Native":5:{s:3:"use";a:1:{s:1:"a";i:100;}s:8:"function";s:47:"function () use (\$a) {
+O:47:"Laravel\SerializableClosure\SerializableClosure":1:{s:12:"serializable";O:46:"Laravel\SerializableClosure\Serializers\Signed":2:{s:12:"serializable";s:264:"O:46:"Laravel\SerializableClosure\Serializers\Native":5:{s:3:"use";a:1:{s:1:"a";i:100;}s:8:"function";s:47:"function () use (\$a) {
         return \$a;
-    }";s:5:"scope";s:22:"P\Tests\SerializerTest";s:4:"this";N;s:4:"self";i:6838;}";s:4:"hash";s:44:"+1lcRO0lDFgbghMrNFtILaGX/14VC8WpQYXUwpIjwVQ=";}}
+    }";s:5:"scope";s:22:"P\Tests\SerializerTest";s:4:"this";N;s:4:"self";
 OEF
     );
 });
@@ -386,7 +386,7 @@ test('unsigned serializable closure serialization string content dont change', f
     expect($actual)->toBe(<<<OEF
 O:55:"Laravel\SerializableClosure\UnsignedSerializableClosure":1:{s:12:"serializable";O:46:"Laravel\SerializableClosure\Serializers\Native":5:{s:3:"use";a:1:{s:1:"a";i:100;}s:8:"function";s:47:"function () use (\$a) {
         return \$a;
-    }";s:5:"scope";s:22:"P\Tests\SerializerTest";s:4:"this";N;s:4:"self";i:2551;}}
+    }";s:5:"scope";s:22:"P\Tests\SerializerTest";s:4:"this";N;s:4:"self";
 OEF
     );
 });

--- a/tests/SerializerTest.php
+++ b/tests/SerializerTest.php
@@ -362,14 +362,20 @@ test('serializable closure serialization string content dont change', function (
         return $a;
     });
 
-    $actual = explode('s:4:"self";', serialize($c))[0].'s:4:"self";';
+    $actual = serialize($c);
 
-    expect($actual)->toBe(<<<OEF
-O:47:"Laravel\SerializableClosure\SerializableClosure":1:{s:12:"serializable";O:46:"Laravel\SerializableClosure\Serializers\Signed":2:{s:12:"serializable";s:264:"O:46:"Laravel\SerializableClosure\Serializers\Native":5:{s:3:"use";a:1:{s:1:"a";i:100;}s:8:"function";s:47:"function () use (\$a) {
-        return \$a;
-    }";s:5:"scope";s:22:"P\Tests\SerializerTest";s:4:"this";N;s:4:"self";
-OEF
-    );
+    // The "self" field is a spl_object_hash() string on PHP < 8.6 and a spl_object_id() integer
+    // on PHP >= 8.6, so its serialized form (and the byte-length prefix of the string containing
+    // it) can't be hardcoded and must be extracted from the actual output instead.
+    preg_match('/s:4:"self";(s:\d+:"[^"]*"|i:\d+);/', $actual, $matches);
+
+    $native = 'O:46:"Laravel\SerializableClosure\Serializers\Native":5:{s:3:"use";a:1:{s:1:"a";i:100;}s:8:"function";s:47:"function () use ($a) {
+        return $a;
+    }";s:5:"scope";s:22:"P\Tests\SerializerTest";s:4:"this";N;s:4:"self";'.$matches[1].';}';
+
+    $expected = 'O:47:"Laravel\SerializableClosure\SerializableClosure":1:{s:12:"serializable";O:46:"Laravel\SerializableClosure\Serializers\Signed":2:{s:12:"serializable";s:'.strlen($native).':"'.$native.'";';
+
+    expect(substr($actual, 0, strlen($expected)))->toBe($expected);
 });
 
 test('unsigned serializable closure serialization string content dont change', function () {

--- a/tests/SerializerTest.php
+++ b/tests/SerializerTest.php
@@ -362,7 +362,7 @@ test('serializable closure serialization string content dont change', function (
         return $a;
     });
 
-    $actual = explode('s:32:', serialize($c))[0];
+    $actual = explode('s:4:"self";', serialize($c))[0].'s:4:"self";';
 
     expect($actual)->toBe(<<<OEF
 O:47:"Laravel\SerializableClosure\SerializableClosure":1:{s:12:"serializable";O:46:"Laravel\SerializableClosure\Serializers\Signed":2:{s:12:"serializable";s:264:"O:46:"Laravel\SerializableClosure\Serializers\Native":5:{s:3:"use";a:1:{s:1:"a";i:100;}s:8:"function";s:47:"function () use (\$a) {
@@ -381,7 +381,7 @@ test('unsigned serializable closure serialization string content dont change', f
         return $a;
     });
 
-    $actual = explode('s:32:', serialize($c))[0];
+    $actual = explode('s:4:"self";', serialize($c))[0].'s:4:"self";';
 
     expect($actual)->toBe(<<<OEF
 O:55:"Laravel\SerializableClosure\UnsignedSerializableClosure":1:{s:12:"serializable";O:46:"Laravel\SerializableClosure\Serializers\Native":5:{s:3:"use";a:1:{s:1:"a";i:100;}s:8:"function";s:47:"function () use (\$a) {


### PR DESCRIPTION
- Use `spl_object_id()` instead of `spl_object_hash()`
- Update GitHub Actions workflows

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
